### PR TITLE
Fixed command to run jekyll locally

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,4 +14,4 @@ If you want to add a new translation, follow these steps:
 2. Copy index.html as index_{langcode}.html
 3. Change the values of the strings to the translated strings.
 
-You can see the translated webpage by running `jekyll --server` and opening http://localhost:4000/
+You can see the translated webpage by running `jekyll serve` and opening http://localhost:4000/


### PR DESCRIPTION
New version of jekyll use `jekyll serve` instead of `jekyll --server`
