### PR TITLE
header ids in index layout.

### DIFF
--- a/_layouts/index.html
+++ b/_layouts/index.html
@@ -158,7 +158,7 @@ Created /usr/local/Library/Formula/bar.rb
 
           <li>
             <div class="group row">
-              <h2>{{ page.pagecontent.install.install }}</h2>
+              <h2 id="install">{{ page.pagecontent.install.install }}</h2>
               <pre style='clear:both;text-align:center;margin:0 -3em;margin-bottom:0.9em'><code id='selectable' onclick="selectText(this)">ruby -e &quot;$(curl -fsSL https://raw.github.com/Homebrew/homebrew/go/install)&quot;</code></pre>
               <div class="col-1">
                 <p>{{ page.pagecontent.install.paste }}</p>
@@ -171,7 +171,7 @@ Created /usr/local/Library/Formula/bar.rb
 
           <li>
             <div class="group row">
-              <h2>{{ page.pagecontent.doc.further }}</h2>
+              <h2 id="further-doc">{{ page.pagecontent.doc.further }}</h2>
               <div class="button">
                 <p><a href="https://github.com/Homebrew/homebrew/wiki">{{ page.pagecontent.doc.wiki }}</a></p>
               </div>


### PR DESCRIPTION
Must be able to direct people directly to the installation
instructions. These `h2` tags make it possible to link to:

http://brew.sh/#install
http://brew.sh/#further-doc
