### PR TITLE
Add Norwegian translation

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -7,6 +7,8 @@ langs:
     lang_string: Español
   - langcode: fr
     lang_string: Français
+  - langcode: 'no'
+    lang_string: Norsk
   - langcode: zh-CN
     lang_string: 简体中文
   - langcode: zh-TW

--- a/index_no.html
+++ b/index_no.html
@@ -1,0 +1,25 @@
+---
+layout: index
+lang: 'no'
+title: Homebrew — MacPorts driving you to drink? Try Homebrew!
+subtitle: OS X’ manglende pakkebehandler
+
+pagecontent:
+  what: Homebrew installerer <a href="https://github.com/Homebrew/homebrew/tree/master/Library/Formula" title="Liste over Homebrew-pakker">alt du trenger</a> som Apple ikke har installert.
+  how: Homebrew installerer pakker i egne mapper, og symlinker filene i <code>/usr/local</code>.
+  prefix: Homebrew installerer ingen filer utenfor sitt område, og du kan plassere en Homebrew-installasjon hvor som helst.
+  createpackages: Du kan enkelt lage dine egne Homebrew-pakker.
+  hack: Under overflaten er alt git og ruby, så hack i vei vel vitende om at du enkelt kan reversere endringene dine og flette inn oppdateringer fra andre.
+  formula: 'Homebrew-formler er simple Ruby-script:'
+  complement: Homebrew utfyller OS X. Installer gems med <code>gem</code>, og pakkene de er avhengige av med <code>brew</code>.
+  install:
+    install: Installer Homebrew
+    paste: Lim dette inn i din Terminal.
+    what: Scriptet forklarer hva det gjør og tar en pause før det gjøres. Du finner flere måter å installere på <a href='https://github.com/Homebrew/homebrew/wiki/Installation'>her</a> (nødvendig på 10.5).
+  doc:
+    further: Videre dokumentasjon
+    wiki: Homebrew-wikien
+  foot:
+    code: Originalkode av <a href="http://methylblue.com/">Max Howell</a>.
+    page: Nettside av <a href="http://exomel.com">Rémi Prévost</a>.
+---


### PR DESCRIPTION
Apparently, the language code for Norwegian, `no`, is treated as `false` by either Jekyll, Liquid or something else. I therefor had to enclose it in quotes. Let me know if this is a problem!
