### PR TITLE
Fix punctuation in Italian translation

### DIFF
--- a/index_it.html
+++ b/index_it.html
@@ -14,7 +14,7 @@ pagecontent:
   complement: Homebrew completa OS X. Installa le tue gemme con <code>gem</code>, e quindi le loro dipendenze con <code>brew</code>.
   install:
     install: Installa Homebrew
-    paste: Incolla questa riga su una finestra del Terminale..
+    paste: Incolla questa riga su una finestra del Terminale.
     what: Lo script ti spiega quello che sta facendo e aspetterà un tuo comando. Ci sono ulterori opzioni di installazione <a href='https://github.com/Homebrew/homebrew/wiki/Installation'>qui</a> (needed on 10.5).
   doc:
     further: Ulteriore Documentazione


### PR DESCRIPTION
Removes a double period from one of the Italian strings. Not really something urgent, but I’m a bit of a perfectionist.
