### PR TITLE
Fixed italian translation

### DIFF
--- a/index_it.html
+++ b/index_it.html
@@ -19,7 +19,7 @@ pagecontent:
     further: Ulteriore Documentazione
     wiki: Homebrew Wiki
   foot:
-    code: Originalmente creato da <a href="http://methylblue.com/">Max Howell</a>.
+    code: Versione originale creata da <a href="http://methylblue.com/">Max Howell</a>.
     page: Sito di <a href="http://exomel.com">Rémi Prévost</a>.
     translation: Traduzione di <a href="http://mattia-asti.it">Mattia Asti</a>
 ---


### PR DESCRIPTION
Just a few fixes of the Italian translation, comprising:
- a typo ("ulterori" rather than "ulteriori")
- a missing conjunction
- the removal of an unnecessary comma
- an alternative version for the translation of "It's all git and ruby underneath
  , so hack away with the knowledge that you can easily revert your modifications and merge upstream updates." 
