### PR TITLE
Alternate mobile styling

### DIFF
--- a/_layouts/index.html
+++ b/_layouts/index.html
@@ -173,7 +173,7 @@ end
           <li>
             <div class="group row">
               <h2 id="install">{{ page.pagecontent.install.install }}</h2>
-              <pre style='clear:both;text-align:center;margin:0 -3em;margin-bottom:0.9em'><code id='selectable' onclick="selectText(this)">ruby -e &quot;$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)&quot;</code></pre>
+              <pre style='clear:both;text-align:center;margin-bottom:0.9em'><code id='selectable' onclick="selectText(this)">ruby -e &quot;$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)&quot;</code></pre>
               <div class="col-1">
                 <p>{{ page.pagecontent.install.paste }}</p>
               </div>

--- a/css/screen.css
+++ b/css/screen.css
@@ -222,6 +222,9 @@ pre code {
     width: 100%;
     float: left;
   }
+  pre code#selectable {
+    width: 90%;
+    margin: 0 auto;
+  }
 }
-
 /*}}}*/


### PR DESCRIPTION
This adds an easier-to-read mobile styling for the website.
Previously, this is what you would see on a smaller screen:
![screenshot 2014-10-15 21 14 57](https://cloud.githubusercontent.com/assets/2782749/4656221/e2d58722-54d1-11e4-9d1a-760928b645a0.png)
Now, you see this:
![screenshot 2014-10-15 21 15 37](https://cloud.githubusercontent.com/assets/2782749/4656226/f690aa4e-54d1-11e4-8ed3-5b934e605f3f.png)
