### PR TITLE
gemfile: bump json version for Ruby 2.2.0 compat

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -81,7 +81,7 @@ GEM
       gemoji (~> 2.0)
       html-pipeline (~> 1.9)
       jekyll (~> 2.0)
-    json (1.8.1)
+    json (1.8.2)
     kramdown (1.3.1)
     liquid (2.6.1)
     listen (2.8.4)


### PR DESCRIPTION
Json broke pretty horrifically for Ruby 2.2.0, see: https://github.com/flori/json/issues/229

This means anyone using 2.2.0 running `jekyll serve` will just run into lots and lots of failure. Upstream released v1.8.2 of Json to fix the issue.