### PR TITLE
Small text translation missing in pt-br version of home page

### DIFF
--- a/index_pt-br.html
+++ b/index_pt-br.html
@@ -4,7 +4,7 @@ lang: pt-BR
 subtitle: O gerenciador de pacotes que faltava para o OS X
 
 pagecontent:
-  question: What Does Homebrew Do?
+  question: O Que O Homebrew Faz?
   what: O Homebrew instala <a href="https://github.com/Homebrew/homebrew/tree/master/Library/Formula" title="Lista de pacotes do Homebrew">as coisas que você precisa</a> que a Apple não forneceu para você.
   how: O Homebrew instala os pacotes em seu próprio diretório e cria link simbólicos dos seus arquivos dentro de <code>/usr/local</code>.
   prefix: O Homebrew não instala arquivos fora de sua estrutura, e você pode colocar a instalação do Homebrew onde desejar.


### PR DESCRIPTION
Translating the subtitle *What Does Homebrew Do?* to Brazilian Portuguese.

Also, I could see that it's not translated in all of other languages. What's the point in keeping this subtitle in English?