### PR TITLE
Removed non-English character in title (Swedish translation)

### DIFF
--- a/index_se.html
+++ b/index_se.html
@@ -4,7 +4,7 @@ lang: se
 subtitle: Den saknade pakethanteraren för OS X
 
 pagecontent:
-  question: Vad är Homebrew?
+  question: What Does Homebrew Do?
   what: Homebrew installerar <a href="https://github.com/Homebrew/homebrew/tree/master/Library/Formula" title="Lista av Homebrew-paket">allt du behöver</a> som Apple inte redan har gjort.
   how: Homebrew installerar paket i egna mappar, och sen symlinkar filera in till <code>/usr/local</code>.
   prefix: Homebrew kommer inte att installera filer utanför sitt område, och du kan placera en installation av Homebrew vart du vill.


### PR DESCRIPTION
Changed “What Does Homebrew Do?” title back to English from Swedish until the issue
with non-English characters have been resolved.