### PR TITLE
Fixed minor misspelling (Swedish translation)

### DIFF
--- a/index_se.html
+++ b/index_se.html
@@ -8,7 +8,7 @@ pagecontent:
   what: Homebrew installerar <a href="https://github.com/Homebrew/homebrew/tree/master/Library/Formula" title="Lista av Homebrew-paket">allt du behöver</a> som Apple inte redan har gjort.
   how: Homebrew installerar paket i egna mappar, och sen symlinkar filera in till <code>/usr/local</code>.
   prefix: Homebrew kommer inte att installera filer utanför sitt område, och du kan placera en installation av Homebrew vart du vill.
-  createpackages: Skapa dina egna Homebrew-packet enkelt.
+  createpackages: Skapa dina egna Homebrew-paket enkelt.
   hack: Under ytan är allt git och ruby, så du kan hacka på med vetskapen att du kan enkelt omvända dina ändringar och sammanfoga med andras modifikationer.
   formula: "Homebrews formler är enkla Rubyskript:"
   editor: öppnas i $EDITOR!


### PR DESCRIPTION
Fixed “packet” to “paket” - minor misspelling in Swedish translation