### PR TITLE
Use full path to Ruby

### DIFF
--- a/_layouts/index.html
+++ b/_layouts/index.html
@@ -70,7 +70,7 @@
             <div class="group row">
               <h2 id="install">{{ page.pagecontent.install.install }}</h2>
               <br>
-              <pre style='clear:both;text-align:center;margin-bottom:0.9em'><code id='selectable' onclick="selectText(this)">ruby -e &quot;$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)&quot;</code></pre>
+              <pre style='clear:both;text-align:center;margin-bottom:0.9em'><code id='selectable' onclick="selectText(this)">/usr/bin/ruby -e &quot;$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)&quot;</code></pre>
               <div class="col-1">
                 <p>{{ page.pagecontent.install.paste }}</p>
               </div>


### PR DESCRIPTION
This avoids errors with broken Ruby installations.