### PR TITLE
Added Danish translations

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -11,6 +11,8 @@ langs:
     lang_string: Български
   - langcode: ca
     lang_string: Català
+  - langcode: da
+    lang_string: Dansk
   - langcode: de
     lang_string: Deutsch
   - langcode: es

--- a/index_da.html
+++ b/index_da.html
@@ -1,0 +1,27 @@
+---
+layout: index
+lang: da
+subtitle: OS X's manglende pakkemanager
+
+pagecontent:
+  question: What Does Homebrew Do?
+  what: Homebrew installerer <a href="https://github.com/Homebrew/homebrew/tree/master/Library/Formula" title="Liste over Homebrew-pakker">alt det du har brug for</a> som Apple ikke gjorde.
+  how: Homebrew installerer pakker i deres egne mapper for så at symlinke deres filer ind i <code>/usr/local</code>.
+  prefix: Homebrew vil ikke installere filer udenfor sit område, og du kan placere en Homebrew-installation hvor end du vil.
+  createpackages: Trivially create your own Homebrew packages.
+  createpackages: Skab dine egne Homebrew-pakker, let og enkelt.
+  hack: Under hjelmen er det bare git og ruby, så hack løs &ndash; velvidende om at du let kan annulere dine ændringer og flette andres rettelser ind.
+  formula: "Homebrew formulae are simple Ruby scripts:"
+  formula: "Homebrew formularer er simple Rubyscripts:"
+  editor: åbner i $EDITOR!
+  complement: Homebrew komplimenterer OS X. Installer dine gems med <code>gem</code> og pakkerne de er afhængige af med <code>brew</code>.
+  install:
+    install: Installer Homebrew
+    paste: Kopier og indsæt i din Terminal
+    what: Scriptet forklarer hvad det vil gøre, og pauser før den gør det. Der findes flere installeringsmuligheder <a href='https://github.com/Homebrew/homebrew/blob/master/share/doc/homebrew/Installation.md#installation' title="Flere installeringsmuligheder">her</a> (krævet i 10.5).
+    doc:
+    further: Videre dokumentation
+  foot:
+    code: Originalkode af <a href="https://mxcl.github.io/">Max Howell</a>.
+    page: Hjemmeside af <a href="http://exomel.com">Rémi Prévost</a>.
+---


### PR DESCRIPTION
The webfont (Chunkfive) seems to not support the Ø and Å glyphs, which are extremely prevalent in Scandinavian languages, which is why the title "What Does Homebrew Do?" is still in English, like the Swedish and Norwegian translations – it's simply impossible to translate that sentence in a meaningful way without those glyphs 🐭