### PR TITLE
OS X -> macOS

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,7 +1,7 @@
 ---
 layout: index
 lang: en
-subtitle: The missing package manager for OS X
+subtitle: The missing package manager for macOS
 
 pagecontent:
   question: What Does Homebrew Do?
@@ -12,7 +12,7 @@ pagecontent:
   hack: It's all git and ruby underneath, so hack away with the knowledge that you can easily revert your modifications and merge upstream updates.
   formula: "Homebrew formulae are simple Ruby scripts:"
   editor: opens in $EDITOR!
-  complement: Homebrew complements OS X. Install your gems with <code>gem</code>, and their dependencies with <code>brew</code>.
+  complement: Homebrew complements macOS. Install your gems with <code>gem</code>, and their dependencies with <code>brew</code>.
   install:
     install: Install Homebrew
     paste: Paste that at a Terminal prompt.

--- a/index_ar.html
+++ b/index_ar.html
@@ -1,7 +1,7 @@
 ---
 layout: index
 lang: ar
-subtitle: مدير الحزم الذي يفتقده Mac OS X
+subtitle: مدير الحزم الذي يفتقده macOS
 direction: rtl
 
 pagecontent:

--- a/index_az.html
+++ b/index_az.html
@@ -1,7 +1,7 @@
 ---
 layout: index
 lang: az
-subtitle: Çatışmayan OS X paket meneceri
+subtitle: Çatışmayan macOS paket meneceri
 font-family: helvetica
 
 pagecontent:
@@ -13,7 +13,7 @@ pagecontent:
   hack: Tamamilə git və ruby üzərində yazılmışdır. Beləliklə, siz yazdığınız kodu geri ala bilər və ya onu yeniləyə bilərsiniz.
   formula: "Homebrew formulaları sadə Ruby proqramlarıdır:"
   editor: opens in $EDITOR!
-  complement: Homebrew OS X-i tamamlayır. Gemlərinizi <code>gem</code> ilə, onların asılılıqlarını isə <code>brew</code> ilə yükləyin.
+  complement: Homebrew macOS-i tamamlayır. Gemlərinizi <code>gem</code> ilə, onların asılılıqlarını isə <code>brew</code> ilə yükləyin.
   install:
     install: Homebrew-i yükləyin
     paste: Bunu Terminal-a əlavə edin.

--- a/index_be.html
+++ b/index_be.html
@@ -1,7 +1,7 @@
 ---
 layout: index
 lang: be
-subtitle: Менеджэр пакетаў для OS X
+subtitle: Менеджэр пакетаў для macOS
 
 pagecontent:
   question: Навошта патрэбен Homebrew?
@@ -12,7 +12,7 @@ pagecontent:
   hack: Усё функцыянуе пад кіраваннем ruby ды git, таму вы можаце з лёгкасцю адмяняць любыя змены ці аб'ядноўваць іх з апстрымам.
   formula: "Формулы Homebrew — гэта простыя скрыпты на Ruby:"
   editor: адкрыецца ў $EDITOR!
-  complement: Homebrew дапаўняе OS X. Усталёўвайце гемы камандай <code>gem</code>, а іх залежнасці — <code>brew</code>.
+  complement: Homebrew дапаўняе macOS. Усталёўвайце гемы камандай <code>gem</code>, а іх залежнасці — <code>brew</code>.
   install:
     install: Усталяванне Homebrew
     paste: Скапіруйце і ўстаўце гэта ў тэрмінал.

--- a/index_bg.html
+++ b/index_bg.html
@@ -1,7 +1,7 @@
 ---
 layout: index
 lang: bg
-subtitle: Мениджър на пакети за OS X
+subtitle: Мениджър на пакети за macOS
 font-family: helvetica
 
 pagecontent:
@@ -13,7 +13,7 @@ pagecontent:
   hack: Под капака е rubi и git, така че с лекота можете да правите промени.
   formula: "Homebrew формулите са прости Ruby скриптове:"
   editor: opens in $EDITOR!
-  complement: Homebrew допълва OS X. Инсталирайте gem пакети, използвайки <code>gem</code>, а техните зависимости чрез <code>brew</code>.
+  complement: Homebrew допълва macOS. Инсталирайте gem пакети, използвайки <code>gem</code>, а техните зависимости чрез <code>brew</code>.
   install:
     install: Инсталиране на Homebrew
     paste: Поставете това в терминал.

--- a/index_ca.html
+++ b/index_ca.html
@@ -1,7 +1,7 @@
 ---
 layout: index
 lang: ca
-subtitle: El gestor de paquets per OS X que faltava
+subtitle: El gestor de paquets per macOS que faltava
 
 pagecontent:
   question: What Does Homebrew Do?
@@ -12,11 +12,11 @@ pagecontent:
   hack: Per sota és tot git i ruby, de manera que pots fer canvis sabent que podràs fer i desfer les teves modificacions i obtenir actualitzacions sense problemes.
   formula: "Les fórmules de Homebrew són senzills <i>scripts</i> Ruby:"
   editor: opens in $EDITOR!
-  complement: Homebrew complementa OS X. Instal·la les teves <i>gems</i> amb <code>gem</code>, i les seves dependències amb <code>brew</code>.
+  complement: Homebrew complementa macOS. Instal·la les teves <i>gems</i> amb <code>gem</code>, i les seves dependències amb <code>brew</code>.
   install:
     install: Instal·la Homebrew
     paste: Enganxa el codi a una finestra de Terminal.
-    what: L'<i>script</i> explica el que fa i s'espera abans de fer-ho. Hi ha més opcions d'instal·lació <a href='https://github.com/Homebrew/brew/blob/master/share/doc/homebrew/Installation.md#installation'>aquí</a> (necessàries per instal·lar Homebrew a OS X 10.5).
+    what: L'<i>script</i> explica el que fa i s'espera abans de fer-ho. Hi ha més opcions d'instal·lació <a href='https://github.com/Homebrew/brew/blob/master/share/doc/homebrew/Installation.md#installation'>aquí</a> (necessàries per instal·lar Homebrew a macOS 10.5).
   doc:
     further: Més Documentació
   foot:

--- a/index_da.html
+++ b/index_da.html
@@ -1,7 +1,7 @@
 ---
 layout: index
 lang: da
-subtitle: OS X's manglende pakkemanager
+subtitle: macOS's manglende pakkemanager
 
 pagecontent:
   question: What Does Homebrew Do?
@@ -14,7 +14,7 @@ pagecontent:
   formula: "Homebrew formulae are simple Ruby scripts:"
   formula: "Homebrew formularer er simple Rubyscripts:"
   editor: åbner i $EDITOR!
-  complement: Homebrew komplimenterer OS X. Installer dine gems med <code>gem</code> og pakkerne de er afhængige af med <code>brew</code>.
+  complement: Homebrew komplimenterer macOS. Installer dine gems med <code>gem</code> og pakkerne de er afhængige af med <code>brew</code>.
   install:
     install: Installer Homebrew
     paste: Kopier og indsæt i din Terminal

--- a/index_de.html
+++ b/index_de.html
@@ -1,7 +1,7 @@
 ---
 layout: index
 lang: de
-subtitle: Der fehlende Paketmanager für OS X
+subtitle: Der fehlende Paketmanager für macOS
 
 pagecontent:
   question: Was macht Homebrew?
@@ -12,7 +12,7 @@ pagecontent:
   hack: Unter der Haube werden git und ruby verwendet. Modifikationen sind also schnell rückgängig gemacht und Upstream-Änderungen lassen sich leicht mergen.
   formula: "Homebrew-Formeln sind einfache Ruby-Skripte:"
   editor: wird in $EDITOR geöffnet!
-  complement: Homebrew ergänzt OS X. Installiere Deine Gems mit <code>gem</code> und ihre Abhängigkeiten mit <code>brew</code>.
+  complement: Homebrew ergänzt macOS. Installiere Deine Gems mit <code>gem</code> und ihre Abhängigkeiten mit <code>brew</code>.
   install:
     install: Installiere Homebrew
     paste: Füge das im Terminal ein.

--- a/index_es.html
+++ b/index_es.html
@@ -1,7 +1,7 @@
 ---
 layout: index
 lang: es
-subtitle: El gestor de paquetes para OS X que faltaba
+subtitle: El gestor de paquetes para macOS que faltaba
 
 pagecontent:
   question: ¿Qué hace el Homebrew?
@@ -12,7 +12,7 @@ pagecontent:
   hack: "Homebrew está basado únicamente en Git y Ruby: ya puedes desarrollar tranquilo, con la seguridad de que podrás deshacer tus cambios e integrar actualizaciones con total facilidad."
   formula: "Las fórmulas de Homebrew son simples <i>scripts</i> en Ruby:"
   editor: opens in $EDITOR!
-  complement: Homebrew complementa OS X. Instala tus <i>gems</i> con <code>gem</code> y sus dependencias con <code>brew</code>.
+  complement: Homebrew complementa macOS. Instala tus <i>gems</i> con <code>gem</code> y sus dependencias con <code>brew</code>.
   install:
     install: Instala Homebrew
     paste: Pega ese código en una ventana del Terminal.

--- a/index_fa.html
+++ b/index_fa.html
@@ -1,7 +1,7 @@
 ---
 layout: index
 lang: fa
-subtitle: مدیریت بسته‌های ناموجود برای OS X
+subtitle: مدیریت بسته‌های ناموجود برای macOS
 direction: rtl
 
 pagecontent:
@@ -13,7 +13,7 @@ pagecontent:
   hack: Homebrew تحت کنترل git و ruby است بنابراین با توجه به اینکه تغییرات داده‌شده به‌راحتی قابل‌برگشت است آن چیزی را که می‌خواهید به دستورات اضافه و یا کم کنید.
   formula: "دستورات Homebrew اسکریپت‌های ساده Ruby هستند:"
   editor: بازنمودن در $EDITOR!
-  complement: Homebrew مکمل OS x است. gemها را با دستور <code>gem</code> و وابستگی‌های (dependencies) آن را با <code>brew</code> نصب کنید.
+  complement: Homebrew مکمل macOS است. gemها را با دستور <code>gem</code> و وابستگی‌های (dependencies) آن را با <code>brew</code> نصب کنید.
   install:
     install: نصب Homebrew
     paste: کد بالا را در خط فرمان ترمینال جایگذاری کنید.

--- a/index_fi.html
+++ b/index_fi.html
@@ -1,7 +1,7 @@
 ---
 layout: index
 lang: fi
-subtitle: Puuttuva pakettienhallinta OS Xlle
+subtitle: Puuttuva pakettienhallinta macOSlle
 
 pagecontent:
   question: Mitä Homebrew tekee?
@@ -12,7 +12,7 @@ pagecontent:
   hack: Siinä on pelkästään gitiä sekä rubyä sisimmässään, joten hakkaa pois tietäen, että voit helposti palauttaa omia muutoksia ja yhdistää ylävirran päivityksiä.
   formula: "Homebrewin kaavat ovat yksinkertaisia Ruby-skriptejä:"
   editor: avautuu editorissa $EDITOR!
-  complement: Homebrew täydentää OS Xää. Asenna jalokivesi <code>gem</code>illä, ja sen riippuvuudet <code>brew</code>illä.
+  complement: Homebrew täydentää macOSää. Asenna jalokivesi <code>gem</code>illä, ja sen riippuvuudet <code>brew</code>illä.
   install:
     install: Asenna Homebrew
     paste: Liitä tämä komentokehotteeseen.

--- a/index_fr.html
+++ b/index_fr.html
@@ -1,7 +1,7 @@
 ---
 layout: index
 lang: fr
-subtitle: Le gestionnaire de paquets pour OS X
+subtitle: Le gestionnaire de paquets pour macOS
 
 pagecontent:
   question: Que fait Homebrew ?
@@ -12,7 +12,7 @@ pagecontent:
   hack: Homebrew utilise git et ruby, vous pouvez donc faire des modifications sans crainte, sachant que vous pourrez facilement les annuler et les intégrer avec les mises à jour futures.
   formula: "Les formules Homebrew sont de simples scripts Ruby :"
   editor: ouvre avec $EDITOR !
-  complement: Homebrew est un complément pour OS X. Installez vos gems avec <code>gem</code>, et leurs dépendances avec <code>brew</code>.
+  complement: Homebrew est un complément pour macOS. Installez vos gems avec <code>gem</code>, et leurs dépendances avec <code>brew</code>.
   install:
     install: Installer Homebrew
     paste: Copiez et collez dans une fenêtre du Terminal.

--- a/index_he.html
+++ b/index_he.html
@@ -1,7 +1,7 @@
 ---
 layout: index
 lang: he
-subtitle: מנהל החבילות החסר עבור OSX
+subtitle: מנהל החבילות החסר עבור macOS
 direction: rtl
 
 pagecontent:
@@ -13,7 +13,7 @@ pagecontent:
   hack: הכל בנוי מעל git ו-ruby, לכן אתם יכולים לשנות דברים ללא חשש מתוך ידיעה שניתן בקלות לבטל את השינויים ולמשוך עדכונים.
   formula: "ב-Homebrew, ״נוסחאות״ ההתקנה הן סקריפטים פשוטים ב-Ruby:"
   editor: opens in $EDITOR!
-  complement: Homebrew משלים את OS X. התקינו את ה-gems שלכם עם <code>gem</code>, ואת התלויות שלהם עם <code>brew</code>.
+  complement: Homebrew משלים את macOS. התקינו את ה-gems שלכם עם <code>gem</code>, ואת התלויות שלהם עם <code>brew</code>.
   install:
     install: התקנת Homebrew
     paste: הדביקו את הנ״ל ב-Terminal.

--- a/index_it.html
+++ b/index_it.html
@@ -1,7 +1,7 @@
 ---
 layout: index
 lang: it
-subtitle: Il gestore di pacchetti mancanti per OS X
+subtitle: Il gestore di pacchetti mancanti per macOS
 
 pagecontent:
   question: Che fa Homebrew?
@@ -12,7 +12,7 @@ pagecontent:
   hack: Tutto si basa su Git e Ruby quindi sentiti libero di sperimentare col codice, sapendo che potrai facilmente fare il revert delle tue modifiche ed il merge con gli aggiornamenti ufficiali.
   formula: "Le formule di Homebrew sono semplici script in Ruby:"
   editor: si apre in $EDITOR!
-  complement: Homebrew completa OS X. Installa le tue gemme con <code>gem</code> e quindi le loro dipendenze con <code>brew</code>.
+  complement: Homebrew completa macOS. Installa le tue gemme con <code>gem</code> e quindi le loro dipendenze con <code>brew</code>.
   install:
     install: Installa Homebrew
     paste: Incolla questa riga su una finestra del Terminale.

--- a/index_ja.html
+++ b/index_ja.html
@@ -1,7 +1,7 @@
 ---
 layout: index
 lang: ja
-subtitle: OS X 用パッケージマネージャー
+subtitle: macOS 用パッケージマネージャー
 
 pagecontent:
   question: Homebrew の仕組み
@@ -12,7 +12,7 @@ pagecontent:
   hack: Homebrew はすべて Git と Ruby で動いているので、あなたが既に持っている知識で簡単に変更できます。
   formula: "Homebrew の formula はシンプルな Ruby スクリプトです:"
   editor: opens in $EDITOR!
-  complement: Homebrew は OS X の機能を補完します。<code>gem</code> コマンドで gem を、そして <code>brew</code> コマンドでそれらの依存関係をインストールします。
+  complement: Homebrew は macOS の機能を補完します。<code>gem</code> コマンドで gem を、そして <code>brew</code> コマンドでそれらの依存関係をインストールします。
   install:
     install: インストール
     paste: このスクリプトをターミナルに貼り付け実行して下さい。

--- a/index_ko.html
+++ b/index_ko.html
@@ -1,7 +1,7 @@
 ---
 layout: index
 lang: ko
-subtitle: OS X 용 패키지 관리자
+subtitle: macOS 용 패키지 관리자
 
 pagecontent:
   question: What Does Homebrew Do?
@@ -12,7 +12,7 @@ pagecontent:
   hack: 모두 git과 ruby 기반으로 되어 있으며, 쉽게 수정을 되돌리거나 원본 코드의 수정사항을 병합하면서 해킹하세요.
   formula: "Homebrew formula는 간단한 Ruby 스크립트입니다:"
   editor: opens in $EDITOR!
-  complement: Homebrew는 OS X 개발 환경을 개선합니다. <code>gem</code> 명령으로 gem을, <code>brew</code> 명령으로 gem의 의존성 모듈을 설치하세요.
+  complement: Homebrew는 macOS 개발 환경을 개선합니다. <code>gem</code> 명령으로 gem을, <code>brew</code> 명령으로 gem의 의존성 모듈을 설치하세요.
   install:
     install: Homebrew 설치하기
     paste: 터미널에 붙여넣기 하세요.

--- a/index_no.html
+++ b/index_no.html
@@ -1,7 +1,7 @@
 ---
 layout: index
 lang: 'no'
-subtitle: OS X’ manglende pakkebehandler
+subtitle: macOS’ manglende pakkebehandler
 
 pagecontent:
   question: What Does Homebrew Do?
@@ -12,7 +12,7 @@ pagecontent:
   hack: Under overflaten er alt git og ruby, så hack i vei vel vitende om at du enkelt kan reversere endringene dine og flette inn oppdateringer fra andre.
   formula: 'Homebrew-formler er simple Ruby-script:'
   editor: opens in $EDITOR!
-  complement: Homebrew utfyller OS X. Installer gems med <code>gem</code>, og pakkene de er avhengige av med <code>brew</code>.
+  complement: Homebrew utfyller macOS. Installer gems med <code>gem</code>, og pakkene de er avhengige av med <code>brew</code>.
   install:
     install: Installer Homebrew
     paste: Lim dette inn i din Terminal.

--- a/index_pl.html
+++ b/index_pl.html
@@ -1,7 +1,7 @@
 ---
 layout: index
 lang: pl
-subtitle: Menadżer brakujących pakietów dla OS X
+subtitle: Menadżer brakujących pakietów dla macOS
 
 pagecontent:
   question: Jak działa Homebrew?
@@ -12,7 +12,7 @@ pagecontent:
   hack: Homebrew to połączenie Gita i Ruby &ndash; dostosuj go do własnych potrzeb wiedząc, że cofanie zmian oraz aktualizacje nie stanowią żadnego problemu.
   formula: "Formuły Homebrewa to proste skrypty napisane w Ruby:"
   editor: opens in $EDITOR!
-  complement: Homebrew jest uzupełnieniem systemu OS X. Instaluj Gemy używając polecenia <code>gem</code>, a ich zależności za pomocą komendy <code>brew</code>.
+  complement: Homebrew jest uzupełnieniem systemu macOS. Instaluj Gemy używając polecenia <code>gem</code>, a ich zależności za pomocą komendy <code>brew</code>.
   install:
     install: Zainstaluj Homebrewa
     paste: Wklej polecenie w swoim Terminalu.

--- a/index_pt-br.html
+++ b/index_pt-br.html
@@ -1,7 +1,7 @@
 ---
 layout: index
 lang: pt-BR
-subtitle: O gerenciador de pacotes que faltava para o OS X
+subtitle: O gerenciador de pacotes que faltava para o macOS
 
 pagecontent:
   question: O Que O Homebrew Faz?
@@ -12,7 +12,7 @@ pagecontent:
   hack: "O Homebrew é baseado unicamente em Git e Ruby: agora você pode desenvolver tranquilo, com a certeza de que você pode desfazer as alterações e integrar atualizações com facilidade."
   formula: Homebrew formulas são simples scripts em Ruby.
   editor: opens in $EDITOR!
-  complement: O Homebrew complementa o OS X. Instale suas gems com <code>gem</code>, e suas dependências com <code>brew</code>.
+  complement: O Homebrew complementa o macOS. Instale suas gems com <code>gem</code>, e suas dependências com <code>brew</code>.
   install:
     install: Instale o Homebrew
     paste: Copie esse código para um prompt do seu Terminal.

--- a/index_ro.html
+++ b/index_ro.html
@@ -1,7 +1,7 @@
 ---
 layout: index
 lang: ro
-subtitle: Managerul de module care lipseste de pe OS X
+subtitle: Managerul de module care lipseste de pe macOS
 
 pagecontent:
   question: Ce este Homebrew?
@@ -12,7 +12,7 @@ pagecontent:
   hack: Este alcătuit din Git și Ruby, deci poți modifica formulele foarte ușor. Dacă le vrei inapoi pe cele originale, nu trebuie decat să le copiezi din ramura de upstream.
   formula: "Formulele Homebrew sunt doar script-uri în Ruby."
   editor: Se deschide în $EDITOR!
-  complement: Homebrew întregește OS X. Instalează gem-urile cu <code>gem</code> și dependențele sale cu <code>brew</code>.
+  complement: Homebrew întregește macOS. Instalează gem-urile cu <code>gem</code> și dependențele sale cu <code>brew</code>.
   install:
     install: Instaleaza Homebrew
     paste: Copiază asta în terminal.

--- a/index_ru.html
+++ b/index_ru.html
@@ -1,7 +1,7 @@
 ---
 layout: index
 lang: ru
-subtitle: Менеджер недостающих пакетов для OS X
+subtitle: Менеджер недостающих пакетов для macOS
 font-family: helvetica
 
 pagecontent:
@@ -13,7 +13,7 @@ pagecontent:
   hack: Под капотом — <code>ruby</code> и <code>git</code>. Так что вы сможете с легкостью откатить ваши изменения и объеденить их с апстримом.
   formula: "Формула Homebrew проста как скрипт на Ruby:"
   editor: opens in $EDITOR!
-  complement: Homebrew дополняет OS X. Устанавливайте гемы, используя <code>gem</code>, а их зависимости через <code>brew</code>.
+  complement: Homebrew дополняет macOS. Устанавливайте гемы, используя <code>gem</code>, а их зависимости через <code>brew</code>.
   install:
     install: Установка Homebrew
     paste: Вставьте это в терминал.

--- a/index_se.html
+++ b/index_se.html
@@ -1,7 +1,7 @@
 ---
 layout: index
 lang: se
-subtitle: Den efterlängtade pakethanteraren för OS X
+subtitle: Den efterlängtade pakethanteraren för macOS
 
 pagecontent:
   question: Vad gör Homebrew?
@@ -12,7 +12,7 @@ pagecontent:
   hack: Under ytan är allt git och ruby, så du kan säkert förändra kod med vetskapen att du kan enkelt omvända dina ändringar och sammanfoga med andras modifikationer.
   formula: "Homebrews formler är enkla Rubyskript:"
   editor: öppnas i $EDITOR!
-  complement: Homebrew kompletterar OS X. Installera gems med <code>gem</code>, och paketen de är beroende av med <code>brew</code>.
+  complement: Homebrew kompletterar macOS. Installera gems med <code>gem</code>, och paketen de är beroende av med <code>brew</code>.
   install:
     install: Installera Homebrew
     paste: Klistra in det här i Terminal.

--- a/index_sr.html
+++ b/index_sr.html
@@ -1,7 +1,7 @@
 ---
 layout: index
 lang: ср
-subtitle: Менаџер пакета који недостаје OS X-у
+subtitle: Менаџер пакета који недостаје macOS-у
 
 pagecontent:
   question: Шта ради Homebrew?
@@ -12,7 +12,7 @@ pagecontent:
   hack: Испод површине се налазе git и ruby, зато се можете играти са знањем да модификације увек можете вратити у првобитно стање и дате ваш допринос.
   formula: "Homebrew формуле су само Ruby скрипте:"
   editor: отвара се у $EDITOR-у!
-  complement: Homebrew допуњава OS X. Инсталирајте gem-ове са <code>gem</code>, и њихове депенденције са <code>brew</code> командом.
+  complement: Homebrew допуњава macOS. Инсталирајте gem-ове са <code>gem</code>, и њихове депенденције са <code>brew</code> командом.
   install:
     install: Инсталирај Homebrew
     paste: Налепите ово у прозор Терминала.

--- a/index_th.html
+++ b/index_th.html
@@ -1,7 +1,7 @@
 ---
 layout: index
 lang: th
-subtitle: แพคเกจเมเนเจอร์ที่ขาดหายไปของ OS X
+subtitle: แพคเกจเมเนเจอร์ที่ขาดหายไปของ macOS
 
 pagecontent:
   question: What Does Homebrew Do?
@@ -12,7 +12,7 @@ pagecontent:
   hack: ภายในทำงานด้วย git และ ruby เพราะฉะนั้นแล้ว คุณเองก็สามารถทำแก้ไขจนพอใจ จากนั้นจึง merge การแก้ไขนั้นไปที่ upstream
   formula: "Homebrew formula เป็นแค่สคริปภาษา Ruby ง่ายๆ:"
   editor: opens in $EDITOR!
-  complement: Homebrew เติมเต็มให้กับ OS X. ติดตั้ง gem ทั้งหลายด้วย <code>gem</code> ส่วน dependency ต่าง ๆ ติดตั้งด้วย <code>brew</code>
+  complement: Homebrew เติมเต็มให้กับ macOS. ติดตั้ง gem ทั้งหลายด้วย <code>gem</code> ส่วน dependency ต่าง ๆ ติดตั้งด้วย <code>brew</code>
   install:
     install: วิธีการติดตั้ง Homebrew
     paste: คัดลอกคำสั่งด้านบนไปรันใน Terminal

--- a/index_tr.html
+++ b/index_tr.html
@@ -1,7 +1,7 @@
 ---
 layout: index
 lang: tr
-subtitle: OS X için eksik paket yöneticisi
+subtitle: macOS için eksik paket yöneticisi
 
 pagecontent:
   question: Homebrew nedir?
@@ -12,7 +12,7 @@ pagecontent:
   hack: Homebrew arkaplanda git ve ruby kullandığından, degişikliklerinizi kolayca ekleyebileceginiz ve geri alabileceginizin güvencesi ile yapabilirsiniz.
   formula: "Homebrew formülleri yalın Ruby betikleridir:"
   editor: $EDITOR de açar!
-  complement: Homebrew OS X'i tamamlar. Gem'lerinizi <code>gem</code> ile, ve gereksinimleri <code>brew</code> ile yükleyin.
+  complement: Homebrew macOS'i tamamlar. Gem'lerinizi <code>gem</code> ile, ve gereksinimleri <code>brew</code> ile yükleyin.
   install:
     install: Homebrew'i yükleyin
     paste: Bunu bir Terminal penceresine yapıştırın.

--- a/index_uk.html
+++ b/index_uk.html
@@ -1,7 +1,7 @@
 ---
 layout: index
 lang: uk
-subtitle: Менеджер пакетів для OS X, якого Вам бракувало
+subtitle: Менеджер пакетів для macOS, якого Вам бракувало
 
 pagecontent:
   question: Для чого потрібен Homebrew?
@@ -12,11 +12,11 @@ pagecontent:
   hack: Всередині це просто git та ruby, тому Ви можете вільно робити все, що заманеться, і бути впевненим, що завжди зможете відновити початковий стан та застосувати оновлення з апстріму.
   formula: "Формули Homebrew — це прості скрипти на Ruby:"
   editor: відкриється в $EDITOR!
-  complement: Homebrew доповнює OS X. Встановлюйте геми з <code>gem</code>, а їх залежності з <code>brew</code>.
+  complement: Homebrew доповнює macOS. Встановлюйте геми з <code>gem</code>, а їх залежності з <code>brew</code>.
   install:
     install: Встановлення Homebrew
     paste: Запустіть цей код в Terminal.
-    what: Перш ніж робити будь-які зміни, скрипт зупиниться для пояснення, що саме буде зроблено. Більше способів установлення описані <a href='https://github.com/Homebrew/brew/blob/master/share/doc/homebrew/Installation.md#installation'>тут</a> (вони необхідні для Mac OS X 10.5).
+    what: Перш ніж робити будь-які зміни, скрипт зупиниться для пояснення, що саме буде зроблено. Більше способів установлення описані <a href='https://github.com/Homebrew/brew/blob/master/share/doc/homebrew/Installation.md#installation'>тут</a> (вони необхідні для Mac macOS 10.5).
   doc:
     further: Більше документації
   foot:

--- a/index_vi.html
+++ b/index_vi.html
@@ -1,7 +1,7 @@
 ---
 layout: index
 lang: vi
-subtitle: Trình quản lý gói mà OS X thiếu
+subtitle: Trình quản lý gói mà macOS thiếu
 
 pagecontent:
   question: What Does Homebrew Do?
@@ -12,7 +12,7 @@ pagecontent:
   hack: Tất cả là git và ruby ở bên dưới, cho nên xin hãy thoải mái hack vì biết rằng bạn có thể hồi phục các thay đổi dễ dàng và nhập nó vào nhánh ở nguồn.
   formula: "Công thức Homebrew đơn giản là Ruby script:"
   editor: opens in $EDITOR!
-  complement: Homebrew bổ sung OS X. Cài gem của bạn với <code>gem</code>, và tất cả các gói phụ thuộc với <code>brew</code>.
+  complement: Homebrew bổ sung macOS. Cài gem của bạn với <code>gem</code>, và tất cả các gói phụ thuộc với <code>brew</code>.
   install:
     install: Cài đặt Homebrew
     paste: Dán nó vào hiện thị của Terminal.

--- a/index_zh-cn.html
+++ b/index_zh-cn.html
@@ -1,7 +1,7 @@
 ---
 layout: index
 lang: zh-CN
-subtitle: OS X 不可或缺的套件管理器
+subtitle: macOS 不可或缺的套件管理器
 
 pagecontent:
   question: What Does Homebrew Do?
@@ -12,7 +12,7 @@ pagecontent:
   hack: 以 git、 ruby 为其筋骨，所以借助您的相关知识，自由修改，并且可以简单撤回您的调改或者合并上游更新。
   formula: Homebrew 的程式都是简单的 Ruby 脚本：
   editor: 使用 $EDITOR 编辑!
-  complement: Homebrew 使 OS X 更完美。使用 <code>gem</code> 来安装 gems、用 <code>brew</code> 来搞定那些依赖包。
+  complement: Homebrew 使 macOS 更完美。使用 <code>gem</code> 来安装 gems、用 <code>brew</code> 来搞定那些依赖包。
   install:
     install: 获取 Homebrew
     paste: 打开终端窗口, 粘贴以上脚本。

--- a/index_zh-tw.html
+++ b/index_zh-tw.html
@@ -1,7 +1,7 @@
 ---
 layout: index
 lang: zh-TW
-subtitle: OS X 缺少的套件管理工具
+subtitle: macOS 缺少的套件管理工具
 
 pagecontent:
   question: What Does Homebrew Do?
@@ -12,7 +12,7 @@ pagecontent:
   hack: 完全以 Git 和 Ruby 為基底，所以你可以盡情地運用這些知識，輕鬆地復原你的修改以及合併上游的更新。
   formula: "Homebrew 的 formula 都是簡單的 Ruby 腳本："
   editor: 使用 $EDITOR 編輯!
-  complement: Homebrew 互補了 OS X，你可以使用 <code>gem</code> 來安裝 Ruby 套件， 而它的依存軟體可以用 <code>brew</code> 安裝。
+  complement: Homebrew 互補了 macOS，你可以使用 <code>gem</code> 來安裝 Ruby 套件， 而它的依存軟體可以用 <code>brew</code> 安裝。
   install:
     install: 安裝 Homebrew
     paste: 在終端機命令列提示貼上這個。


### PR DESCRIPTION
This also fixes some inconsistencies throughout such as 'Mac OS X', 'OS X', 'OSX'.