### PR TITLE
Fix documentation links

### DIFF
--- a/index.html
+++ b/index.html
@@ -16,7 +16,7 @@ pagecontent:
   install:
     install: Install Homebrew
     paste: Paste that at a Terminal prompt.
-    what: The script explains what it will do and then pauses before it does it. There are more installation options <a href='https://github.com/Homebrew/brew/blob/master/share/doc/homebrew/Installation.md#installation'>here</a> (needed on 10.5).
+    what: The script explains what it will do and then pauses before it does it. There are more installation options <a href='https://github.com/Homebrew/brew/blob/master/docs/Installation.md#installation'>here</a> (needed on 10.5).
   doc:
     further: Further Documentation
   foot:

--- a/index_ar.html
+++ b/index_ar.html
@@ -17,7 +17,7 @@ pagecontent:
   install:
     install: ثبّت Homebrew
     paste: الصق ذلك في الطرفية
-    what: السكربت سيوضح ماذا سيفعل ثم سيتوقف قبل فعله. هناك خيارات تثبيت اضافية <a href='https://github.com/Homebrew/brew/blob/master/share/doc/homebrew/Installation.md#installation'>هنا</a>, مطلوب للإصدار ١٠.٥
+    what: السكربت سيوضح ماذا سيفعل ثم سيتوقف قبل فعله. هناك خيارات تثبيت اضافية <a href='https://github.com/Homebrew/brew/blob/master/docs/Installation.md#installation'>هنا</a>, مطلوب للإصدار ١٠.٥
   doc:
     further: معلومات إضافية
   foot:

--- a/index_az.html
+++ b/index_az.html
@@ -17,7 +17,7 @@ pagecontent:
   install:
     install: Homebrew-i yükləyin
     paste: Bunu Terminal-a əlavə edin.
-    what: Əməliyyatı yerinə yetirməmişdən əvvəl proqram sizə əməliyyat barədə məlumat verir. Daha çox yükləmə üsulları <a href='https://github.com/Homebrew/brew/blob/master/share/doc/homebrew/Installation.md#installation'>buradadır</a> (10.5 üçün lazımdır).
+    what: Əməliyyatı yerinə yetirməmişdən əvvəl proqram sizə əməliyyat barədə məlumat verir. Daha çox yükləmə üsulları <a href='https://github.com/Homebrew/brew/blob/master/docs/Installation.md#installation'>buradadır</a> (10.5 üçün lazımdır).
   doc:
     further: Əlavə Sənədlər
   foot:

--- a/index_be.html
+++ b/index_be.html
@@ -16,7 +16,7 @@ pagecontent:
   install:
     install: Усталяванне Homebrew
     paste: Скапіруйце і ўстаўце гэта ў тэрмінал.
-    what: Перад выкананнем якога-небудзь дзеянні, скрыпт прыпыніцца і растлумачыць, што ён збіраецца зрабіць. Дадатковыя параметры ўстаноўкі можна знайсці <a href='https://github.com/Homebrew/brew/blob/master/share/doc/homebrew/Installation.md#installation'>тут</a> (трэба для версіі 10.5).
+    what: Перад выкананнем якога-небудзь дзеянні, скрыпт прыпыніцца і растлумачыць, што ён збіраецца зрабіць. Дадатковыя параметры ўстаноўкі можна знайсці <a href='https://github.com/Homebrew/brew/blob/master/docs/Installation.md#installation'>тут</a> (трэба для версіі 10.5).
   doc:
     further: Дадатковая дакументацыя
   foot:

--- a/index_ca.html
+++ b/index_ca.html
@@ -16,7 +16,7 @@ pagecontent:
   install:
     install: Instal·la Homebrew
     paste: Enganxa el codi a una finestra de Terminal.
-    what: L'<i>script</i> explica el que fa i s'espera abans de fer-ho. Hi ha més opcions d'instal·lació <a href='https://github.com/Homebrew/brew/blob/master/share/doc/homebrew/Installation.md#installation'>aquí</a> (necessàries per instal·lar Homebrew a macOS 10.5).
+    what: L'<i>script</i> explica el que fa i s'espera abans de fer-ho. Hi ha més opcions d'instal·lació <a href='https://github.com/Homebrew/brew/blob/master/docs/Installation.md#installation'>aquí</a> (necessàries per instal·lar Homebrew a macOS 10.5).
   doc:
     further: Més Documentació
   foot:

--- a/index_da.html
+++ b/index_da.html
@@ -18,7 +18,7 @@ pagecontent:
   install:
     install: Installer Homebrew
     paste: Kopier og indsæt i din Terminal
-    what: Scriptet forklarer hvad det vil gøre, og pauser før den gør det. Der findes flere installeringsmuligheder <a href='https://github.com/Homebrew/brew/blob/master/share/doc/homebrew/Installation.md#installation' title="Flere installeringsmuligheder">her</a> (krævet i 10.5).
+    what: Scriptet forklarer hvad det vil gøre, og pauser før den gør det. Der findes flere installeringsmuligheder <a href='https://github.com/Homebrew/brew/blob/master/docs/Installation.md#installation' title="Flere installeringsmuligheder">her</a> (krævet i 10.5).
     doc:
     further: Videre dokumentation
   foot:

--- a/index_de.html
+++ b/index_de.html
@@ -16,7 +16,7 @@ pagecontent:
   install:
     install: Installiere Homebrew
     paste: Füge das im Terminal ein.
-    what: Das Skript erklärt Dir, was es tun wird und pausiert, bevor es etwas macht. Mehr Installationsoptionen findest Du <a href='https://github.com/Homebrew/brew/blob/master/share/doc/homebrew/Installation.md#installation'>hier</a> (werden unter 10.5 benötigt).
+    what: Das Skript erklärt Dir, was es tun wird und pausiert, bevor es etwas macht. Mehr Installationsoptionen findest Du <a href='https://github.com/Homebrew/brew/blob/master/docs/Installation.md#installation'>hier</a> (werden unter 10.5 benötigt).
   doc:
     further: Weitere Dokumentation
   foot:

--- a/index_es.html
+++ b/index_es.html
@@ -16,7 +16,7 @@ pagecontent:
   install:
     install: Instala Homebrew
     paste: Pega ese código en una ventana del Terminal.
-    what: El programa de instalación explica en cada paso del proceso qué es lo que va a hacer y se toma una pausa para confirmar antes de empezar cada uno de los pasos. Puedes encontrar más opciones de instalación <a href='https://github.com/Homebrew/brew/blob/master/share/doc/homebrew/Installation.md#installation'>aquí</a> (son necesarias para instalar Homebrew en 10.5).
+    what: El programa de instalación explica en cada paso del proceso qué es lo que va a hacer y se toma una pausa para confirmar antes de empezar cada uno de los pasos. Puedes encontrar más opciones de instalación <a href='https://github.com/Homebrew/brew/blob/master/docs/Installation.md#installation'>aquí</a> (son necesarias para instalar Homebrew en 10.5).
   doc:
     further: Documentos adicionales
   foot:

--- a/index_fa.html
+++ b/index_fa.html
@@ -17,7 +17,7 @@ pagecontent:
   install:
     install: نصب Homebrew
     paste: کد بالا را در خط فرمان ترمینال جایگذاری کنید.
-    what: اسکریپت قبل از انجام هر مرحله مکث کرده و به توضیح کاری که می‌خواهد انجام دهد می‌پردازد. گزینه‌های بیشتری برای نصب <a href='https://github.com/Homebrew/brew/blob/master/share/doc/homebrew/Installation.md#installation'>اینجا</a>  موجود است. نسخه ۱۰.۵ نیاز است.
+    what: اسکریپت قبل از انجام هر مرحله مکث کرده و به توضیح کاری که می‌خواهد انجام دهد می‌پردازد. گزینه‌های بیشتری برای نصب <a href='https://github.com/Homebrew/brew/blob/master/docs/Installation.md#installation'>اینجا</a>  موجود است. نسخه ۱۰.۵ نیاز است.
   doc:
     further: مستندات بیشتر
   foot:

--- a/index_fi.html
+++ b/index_fi.html
@@ -16,7 +16,7 @@ pagecontent:
   install:
     install: Asenna Homebrew
     paste: Liitä tämä komentokehotteeseen.
-    what: Skripti kertoo mitä se tekee, ja pysäyttää sen ennen kuin tekee sen. Lisää asennusvaihtoehtoja löytyy <a href='https://github.com/Homebrew/brew/blob/master/share/doc/homebrew/Installation.md#installation'>täältä</a> (vaadittu 10.5ssä).
+    what: Skripti kertoo mitä se tekee, ja pysäyttää sen ennen kuin tekee sen. Lisää asennusvaihtoehtoja löytyy <a href='https://github.com/Homebrew/brew/blob/master/docs/Installation.md#installation'>täältä</a> (vaadittu 10.5ssä).
   doc:
     further: Laajempi dokumentaatio
   foot:

--- a/index_fr.html
+++ b/index_fr.html
@@ -16,7 +16,7 @@ pagecontent:
   install:
     install: Installer Homebrew
     paste: Copiez et collez dans une fenêtre du Terminal.
-    what: Le script explique ce qu’il va faire, puis fait une pause avant de l’exécuter. Plus d’options d’installation sont disponibles <a href="https://github.com/Homebrew/brew/blob/master/share/doc/homebrew/Installation.md#installation">ici</a> (requis pour 10.5).
+    what: Le script explique ce qu’il va faire, puis fait une pause avant de l’exécuter. Plus d’options d’installation sont disponibles <a href="https://github.com/Homebrew/brew/blob/master/docs/Installation.md#installation">ici</a> (requis pour 10.5).
   doc:
     further: Documentation additionnelle
   foot:

--- a/index_he.html
+++ b/index_he.html
@@ -17,7 +17,7 @@ pagecontent:
   install:
     install: התקנת Homebrew
     paste: הדביקו את הנ״ל ב-Terminal.
-    what: הסקריפט יסביר מה הוא יעשה ויעצור לפני שיעשה זאת. קיימות אופציות התקנה נוספות <a href='https://github.com/Homebrew/brew/blob/master/share/doc/homebrew/Installation.md#installation'>כאן</a>, אשר נדרשות ב-10.5
+    what: הסקריפט יסביר מה הוא יעשה ויעצור לפני שיעשה זאת. קיימות אופציות התקנה נוספות <a href='https://github.com/Homebrew/brew/blob/master/docs/Installation.md#installation'>כאן</a>, אשר נדרשות ב-10.5
   doc:
     further: דוקומנטציה נוספת
   foot:

--- a/index_it.html
+++ b/index_it.html
@@ -16,7 +16,7 @@ pagecontent:
   install:
     install: Installa Homebrew
     paste: Incolla questa riga su una finestra del Terminale.
-    what: Lo script ti spiega quello che sta facendo e aspetterà un tuo comando. Ci sono ulteriori <a href='https://github.com/Homebrew/brew/blob/master/share/doc/homebrew/Installation.md#installation'>opzioni di installazione</a> (necessarie sulla 10.5).
+    what: Lo script ti spiega quello che sta facendo e aspetterà un tuo comando. Ci sono ulteriori <a href='https://github.com/Homebrew/brew/blob/master/docs/Installation.md#installation'>opzioni di installazione</a> (necessarie sulla 10.5).
   doc:
     further: Ulteriore documentazione
   foot:

--- a/index_ja.html
+++ b/index_ja.html
@@ -16,7 +16,7 @@ pagecontent:
   install:
     install: インストール
     paste: このスクリプトをターミナルに貼り付け実行して下さい。
-    what: スクリプトは何をするのか説明し、実際にインストールを実行する前に一度中断します。<a href='https://github.com/Homebrew/brew/blob/master/share/doc/homebrew/Installation.md#installation'>こちら</a>でインストールオプションを確認できます。(10.5 が必要です)
+    what: スクリプトは何をするのか説明し、実際にインストールを実行する前に一度中断します。<a href='https://github.com/Homebrew/brew/blob/master/docs/Installation.md#installation'>こちら</a>でインストールオプションを確認できます。(10.5 が必要です)
   doc:
     further: さらに詳しいドキュメント
   foot:

--- a/index_ko.html
+++ b/index_ko.html
@@ -16,7 +16,7 @@ pagecontent:
   install:
     install: Homebrew 설치하기
     paste: 터미널에 붙여넣기 하세요.
-    what: 해당 스크립트는 무엇을 할지 설명하고 실행하기 전에 잠시 멈춥니다. 더 자세한 설치 관련사항을 보려면 <a href='https://github.com/Homebrew/brew/blob/master/share/doc/homebrew/Installation.md#installation'>여기</a>를 참고하세요 (10.5 버전 필요).
+    what: 해당 스크립트는 무엇을 할지 설명하고 실행하기 전에 잠시 멈춥니다. 더 자세한 설치 관련사항을 보려면 <a href='https://github.com/Homebrew/brew/blob/master/docs/Installation.md#installation'>여기</a>를 참고하세요 (10.5 버전 필요).
   doc:
     further: 추가 문서
   foot:

--- a/index_nl.html
+++ b/index_nl.html
@@ -16,7 +16,7 @@ pagecontent:
   install:
     install: Installeer Homebrew
     paste: Plak het bovenstaande in Terminal.
-    what: Het installatiescript beschrijft wat het wilt doen en pauzeert voordat de installatie wordt uitgevoerd. Er zijn meer installatie-opties <a href='https://github.com/Homebrew/brew/blob/master/share/doc/homebrew/Installation.md#installation'>hier</a> beschikbaar (nodig voor 10.5).
+    what: Het installatiescript beschrijft wat het wilt doen en pauzeert voordat de installatie wordt uitgevoerd. Er zijn meer installatie-opties <a href='https://github.com/Homebrew/brew/blob/master/docs/Installation.md#installation'>hier</a> beschikbaar (nodig voor 10.5).
   doc:
     further: Verdere documentatie
   foot:

--- a/index_no.html
+++ b/index_no.html
@@ -16,7 +16,7 @@ pagecontent:
   install:
     install: Installer Homebrew
     paste: Lim dette inn i din Terminal.
-    what: Scriptet forklarer hva det gjør og tar en pause før det gjøres. Du finner flere måter å installere på <a href='https://github.com/Homebrew/brew/blob/master/share/doc/homebrew/Installation.md#installation'>her</a> (nødvendig på 10.5).
+    what: Scriptet forklarer hva det gjør og tar en pause før det gjøres. Du finner flere måter å installere på <a href='https://github.com/Homebrew/brew/blob/master/docs/Installation.md#installation'>her</a> (nødvendig på 10.5).
   doc:
     further: Videre dokumentasjon
   foot:

--- a/index_pl.html
+++ b/index_pl.html
@@ -16,7 +16,7 @@ pagecontent:
   install:
     install: Zainstaluj Homebrewa
     paste: Wklej polecenie w swoim Terminalu.
-    what: Skrypt instalacyjny wyjaśnia jakie zmiany zamierza wprowadzić, po czym zatrzymuje się czekając na ich akceptację. Po więcej opcji instalacji zajrzyj <a href='https://github.com/Homebrew/brew/blob/master/share/doc/homebrew/Installation.md#installation'>tutaj</a> (wymagane w wersji 10.5).
+    what: Skrypt instalacyjny wyjaśnia jakie zmiany zamierza wprowadzić, po czym zatrzymuje się czekając na ich akceptację. Po więcej opcji instalacji zajrzyj <a href='https://github.com/Homebrew/brew/blob/master/docs/Installation.md#installation'>tutaj</a> (wymagane w wersji 10.5).
   doc:
     further: Dalsza dokumentacja
   foot:

--- a/index_pt-br.html
+++ b/index_pt-br.html
@@ -16,7 +16,7 @@ pagecontent:
   install:
     install: Instale o Homebrew
     paste: Copie esse código para um prompt do seu Terminal.
-    what: O script explica o que irá fazer e faz uma pausa antes de ser executado. Há mais opções de instalação <a href='https://github.com/Homebrew/brew/blob/master/share/doc/homebrew/Installation.md#installation'>aqui</a> (necessário para 10.5).
+    what: O script explica o que irá fazer e faz uma pausa antes de ser executado. Há mais opções de instalação <a href='https://github.com/Homebrew/brew/blob/master/docs/Installation.md#installation'>aqui</a> (necessário para 10.5).
   doc:
     further: Documentos Adicionais
   foot:

--- a/index_ro.html
+++ b/index_ro.html
@@ -16,7 +16,7 @@ pagecontent:
   install:
     install: Instaleaza Homebrew
     paste: Copiază asta în terminal.
-    what: Script-ul îți va explica ce vrea să facă și va lua o pauză înainte de a continua. Poți găsi mai multe opțiuni de instalare <a href='https://github.com/Homebrew/brew/blob/master/share/doc/homebrew/Installation.md#installation'>aici</a> (este nevoie de versiunea 10.5).
+    what: Script-ul îți va explica ce vrea să facă și va lua o pauză înainte de a continua. Poți găsi mai multe opțiuni de instalare <a href='https://github.com/Homebrew/brew/blob/master/docs/Installation.md#installation'>aici</a> (este nevoie de versiunea 10.5).
   doc:
     further: Documentatie amanuntita
   foot:

--- a/index_se.html
+++ b/index_se.html
@@ -16,7 +16,7 @@ pagecontent:
   install:
     install: Installera Homebrew
     paste: Klistra in det här i Terminal.
-    what: Skriptet förklarar vad den kommer att installera och pausar före installationen sker. Det finns fler installationsalternativ <a href='https://github.com/Homebrew/brew/blob/master/share/doc/homebrew/Installation.md#installation'>här</a> (nödvändig på 10.5).
+    what: Skriptet förklarar vad den kommer att installera och pausar före installationen sker. Det finns fler installationsalternativ <a href='https://github.com/Homebrew/brew/blob/master/docs/Installation.md#installation'>här</a> (nödvändig på 10.5).
   doc:
     further: Vidare Dokumentation
   foot:

--- a/index_sr.html
+++ b/index_sr.html
@@ -16,7 +16,7 @@ pagecontent:
   install:
     install: Инсталирај Homebrew
     paste: Налепите ово у прозор Терминала.
-    what: Скрипта ће да се паузира и објасни шта ради пре него што то и уради. Више опција ѕа инсталацију постоји <a href='https://github.com/Homebrew/brew/blob/master/share/doc/homebrew/Installation.md#installation'>овде</a> (потребно у 10.5).
+    what: Скрипта ће да се паузира и објасни шта ради пре него што то и уради. Више опција ѕа инсталацију постоји <a href='https://github.com/Homebrew/brew/blob/master/docs/Installation.md#installation'>овде</a> (потребно у 10.5).
   doc:
     further: Даља Документација
   foot:

--- a/index_th.html
+++ b/index_th.html
@@ -16,7 +16,7 @@ pagecontent:
   install:
     install: วิธีการติดตั้ง Homebrew
     paste: คัดลอกคำสั่งด้านบนไปรันใน Terminal
-    what: สคริปจะมีการอธิบายให้รู้ก่อนว่ากำลังจะทำอะไร จากนั้นจะหยุดถามก่อนที่มันจะเริ่มทำ สามารถดูตัวเลือกในการติดตั้งต่าง ๆ ได้จาก<a href='https://github.com/Homebrew/brew/blob/master/share/doc/homebrew/Installation.md#installation'>ที่นี่</a> (ต้องการเวอร์ชัน 10.5)
+    what: สคริปจะมีการอธิบายให้รู้ก่อนว่ากำลังจะทำอะไร จากนั้นจะหยุดถามก่อนที่มันจะเริ่มทำ สามารถดูตัวเลือกในการติดตั้งต่าง ๆ ได้จาก<a href='https://github.com/Homebrew/brew/blob/master/docs/Installation.md#installation'>ที่นี่</a> (ต้องการเวอร์ชัน 10.5)
   doc:
     further: เอกสารอื่น ๆ
   foot:

--- a/index_tr.html
+++ b/index_tr.html
@@ -16,7 +16,7 @@ pagecontent:
   install:
     install: Homebrew'i yükleyin
     paste: Bunu bir Terminal penceresine yapıştırın.
-    what: Betik yapacaklarını açıklayıp sizden komut bekler. <a href="https://github.com/Homebrew/brew/blob/master/share/doc/homebrew/Installation.md#installation">Burada</a> (10.5 için gereklidir) başka kurulum seçenekleri de bulabilirsiniz.
+    what: Betik yapacaklarını açıklayıp sizden komut bekler. <a href="https://github.com/Homebrew/brew/blob/master/docs/Installation.md#installation">Burada</a> (10.5 için gereklidir) başka kurulum seçenekleri de bulabilirsiniz.
   doc:
     further: İlave Dökümantasyon
   foot:

--- a/index_uk.html
+++ b/index_uk.html
@@ -16,7 +16,7 @@ pagecontent:
   install:
     install: Встановлення Homebrew
     paste: Запустіть цей код в Terminal.
-    what: Перш ніж робити будь-які зміни, скрипт зупиниться для пояснення, що саме буде зроблено. Більше способів установлення описані <a href='https://github.com/Homebrew/brew/blob/master/share/doc/homebrew/Installation.md#installation'>тут</a> (вони необхідні для Mac macOS 10.5).
+    what: Перш ніж робити будь-які зміни, скрипт зупиниться для пояснення, що саме буде зроблено. Більше способів установлення описані <a href='https://github.com/Homebrew/brew/blob/master/docs/Installation.md#installation'>тут</a> (вони необхідні для Mac macOS 10.5).
   doc:
     further: Більше документації
   foot:

--- a/index_vi.html
+++ b/index_vi.html
@@ -16,7 +16,7 @@ pagecontent:
   install:
     install: Cài đặt Homebrew
     paste: Dán nó vào hiện thị của Terminal.
-    what: Đoạn script giải thích các bước sẽ được thực hiện và sẽ dừng trước khi thực thi. Có nhiều lựa chọn cài đặt <a href='https://github.com/Homebrew/brew/blob/master/share/doc/homebrew/Installation.md#installation'>ở đây</a> (cần thiết trên 10.5).
+    what: Đoạn script giải thích các bước sẽ được thực hiện và sẽ dừng trước khi thực thi. Có nhiều lựa chọn cài đặt <a href='https://github.com/Homebrew/brew/blob/master/docs/Installation.md#installation'>ở đây</a> (cần thiết trên 10.5).
   doc:
     further: Tra khảo thêm
   foot:

--- a/index_zh-cn.html
+++ b/index_zh-cn.html
@@ -16,7 +16,7 @@ pagecontent:
   install:
     install: 获取 Homebrew
     paste: 打开终端窗口, 粘贴以上脚本。
-    what: 脚本会解释它的作用，然后在您的确认下执行安装。高级安装选项请看 <a href='https://github.com/Homebrew/brew/blob/master/share/doc/homebrew/Installation.md#installation'>这里</a>（需要10.5）。
+    what: 脚本会解释它的作用，然后在您的确认下执行安装。高级安装选项请看 <a href='https://github.com/Homebrew/brew/blob/master/docs/Installation.md#installation'>这里</a>（需要10.5）。
   doc:
     further: 更多文档
   foot:

--- a/index_zh-tw.html
+++ b/index_zh-tw.html
@@ -16,7 +16,7 @@ pagecontent:
   install:
     install: 安裝 Homebrew
     paste: 在終端機命令列提示貼上這個。
-    what: 腳本執行時會解釋它正在做什麼，並在你確認之前暫停下來。你可以在<a href='https://github.com/Homebrew/brew/blob/master/share/doc/homebrew/Installation.md#installation'>這裡</a>找到更多安裝選擇（需要 10.5 以上版本）。
+    what: 腳本執行時會解釋它正在做什麼，並在你確認之前暫停下來。你可以在<a href='https://github.com/Homebrew/brew/blob/master/docs/Installation.md#installation'>這裡</a>找到更多安裝選擇（需要 10.5 以上版本）。
   doc:
     further: 更多說明文件
   foot:


### PR DESCRIPTION
brew's documentation moved from `share/doc/homebrew` to `docs` in the Homebrew/brew repository.

Fixes Homebrew/brew#1048.