### PR TITLE
Fix 1.0.0 blog post date.

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -77,6 +77,7 @@ highlighter: rouge
 exclude: [bin, vendor, CNAME, Gemfile, Gemfile.lock, Rakefile, README.md]
 
 gems:
+  - jekyll-redirect-from
   - jekyll-sitemap
   - jekyll-feed
   - jekyll-seo-tag

--- a/_posts/2016-09-21-homebrew-1.0.0.md
+++ b/_posts/2016-09-21-homebrew-1.0.0.md
@@ -1,6 +1,7 @@
 ---
 title: 1.0.0
 author: MikeMcQuaid
+redirect_from: /2016/09/02/homebrew-1.0.0/
 ---
 Today I'm proud to announce Homebrew 1.0.0. In the seven years since Homebrew was created by [@mxcl](https://github.com/mxcl) our community has grown to [almost 6000 unique contributors](https://github.com/Homebrew/homebrew-core/graphs/contributors), a [wide-reaching third-party "tap" ecosystem](https://github.com/search?p=2&q=homebrew-&type=Repositories&utf8=✓) and [thousands of packages](https://github.com/Homebrew/homebrew-core/tree/master/Formula).
 

--- a/favicon.ico
+++ b/favicon.ico
@@ -1,0 +1,1 @@
+img/favicon.ico


### PR DESCRIPTION
And redirect from the old one.

Whoops!