### PR TITLE
Make the header logo go to homepage

### DIFF
--- a/_layouts/base.html
+++ b/_layouts/base.html
@@ -44,7 +44,7 @@
     <div id="wrap">
       <div id="header" class="{{ page.header-class }}">
         <img alt="Homebrew logo" src="/img/homebrew-256x256.png" width="128px" height="128px">
-        <h1><a href="./">Homebrew</a></h1>
+        <h1><a href="/">Homebrew</a></h1>
         {% if page.subtitle %}
         <p id="subtitle"><strong>{{ page.subtitle }}</strong></p>
         {% endif %}


### PR DESCRIPTION
This might be intentional, but I think the main logo should bring the user to the homepage and not keep reloading the same current page like it does now.

Currently for example, the header logo on `http://brew.sh/2016/09/02/homebrew-1.0.0/` points to `http://brew.sh/2016/09/02/homebrew-1.0.0/` and not `http://brew.sh`.