### PR TITLE
Fix html validation errors

### DIFF
--- a/_layouts/base.html
+++ b/_layouts/base.html
@@ -10,7 +10,7 @@
     {% else %}
     <title>Homebrew — {{ page.subtitle }}</title>
     {% endif %}
-    {% seo %}
+    {% seo title=false %}
     {% feed_meta %}
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <link rel="shortcut icon" href="/img/favicon.ico">

--- a/_layouts/base.html
+++ b/_layouts/base.html
@@ -43,7 +43,7 @@
   <body>
     <div id="wrap">
       <div id="header" class="{{ page.header-class }}">
-        <img alt="Homebrew logo" src="/img/homebrew-256x256.png" width="128px" height="128px">
+        <img alt="Homebrew logo" src="/img/homebrew-256x256.png" width="128" height="128">
         <h1><a href="/">Homebrew</a></h1>
         {% if page.subtitle %}
         <p id="subtitle"><strong>{{ page.subtitle }}</strong></p>


### PR DESCRIPTION
I [ran the site through W3C validator](https://validator.w3.org/nu/?showimagereport=yes&doc=http%3A%2F%2Fbrew.sh%2F) and noticed two simple errors:

1. Duplicate `<title>` elements due to the SEO plugin, which is unfortunate when there's a beautiful display of multilingualism going on.

2. Non-digits inside the `width` and `height` attributes of an `img` element for the logo.

Cheers 🎉