### PR TITLE
Update Pygments color scheme

### DIFF
--- a/css/pygments.css
+++ b/css/pygments.css
@@ -27,11 +27,11 @@
 .s { color: #bb8844 } /* Literal.String */
 .na { color: #008080 } /* Name.Attribute */
 .nb { color: #999999 } /* Name.Builtin */
-.nc { color: #445588; font-weight: bold } /* Name.Class */
-.no { color: #008080 } /* Name.Constant */
+.nc { color: #999999; font-weight: bold } /* Name.Class */
+.no { color: #666666 } /* Name.Constant */
 .ni { color: #800080 } /* Name.Entity */
 .ne { color: #990000; font-weight: bold } /* Name.Exception */
-.nf { color: #990000; font-weight: bold } /* Name.Function */
+.nf { color: #999999; font-weight: bold } /* Name.Function */
 .nn { color: #555555 } /* Name.Namespace */
 .nt { color: #000080 } /* Name.Tag */
 .nv { color: #008080 } /* Name.Variable */
@@ -44,13 +44,13 @@
 .sb { color: #bb8844 } /* Literal.String.Backtick */
 .sc { color: #bb8844 } /* Literal.String.Char */
 .sd { color: #bb8844 } /* Literal.String.Doc */
-.s2 { color: #bb8844 } /* Literal.String.Double */
+.s2 { color: #9c7645 } /* Literal.String.Double */
 .se { color: #bb8844 } /* Literal.String.Escape */
 .sh { color: #bb8844 } /* Literal.String.Heredoc */
 .si { color: #bb8844 } /* Literal.String.Interpol */
 .sx { color: #bb8844 } /* Literal.String.Other */
 .sr { color: #808000 } /* Literal.String.Regex */
-.s1 { color: #bb8844 } /* Literal.String.Single */
+.s1 { color: #9c7645 } /* Literal.String.Single */
 .ss { color: #bb8844 } /* Literal.String.Symbol */
 .bp { color: #999999 } /* Name.Builtin.Pseudo */
 .vc { color: #008080 } /* Name.Variable.Class */


### PR DESCRIPTION
_These are the same changes as #134 but without Pygments/Rouge removed_ 😄 

***

So I promised to revisit the syntax highlighting color scheme because I think it clashes with the rest of the site.

#### Before

<img width="920" alt="" src="https://cloud.githubusercontent.com/assets/11348/18812008/670d1db6-8293-11e6-93af-c92bd3d239a5.png">

#### After

<img width="903" alt="" src="https://cloud.githubusercontent.com/assets/11348/18812011/6b5e47b4-8293-11e6-9143-fa61b4dfb139.png">

Let me know what you think!