### PR TITLE
Add hreflang attribute links to head

### DIFF
--- a/_layouts/base.html
+++ b/_layouts/base.html
@@ -39,6 +39,14 @@
       ga('send', 'pageview');
 
     </script>
+    {% for lang in site.langs %}
+      {% if lang.langcode == "en" %}
+      <link rel="alternate" hreflang="en" href="{{ site.url | append: '/index.html' }}" />
+      <link rel="alternate" hreflang="x-default" href="{{ site.url | append: '/index.html' }}" />
+      {% else %}
+      <link rel="alternate" hreflang="{{ lang.langcode }}" href="{{ lang.langcode | downcase | append: '.html' | prepend: '/index_' | prepend: site.url }}" />
+      {% endif %}
+    {% endfor %}
   </head>
   <body>
     <div id="wrap">


### PR DESCRIPTION
This adds `<link>`s with attribute `hreflang` to `<head>`. Search engines such as Google support this attribute and will use it for indexing and localising search results. Perhaps this improves the discovery of the language-specific page in the search results.

Reference: https://support.google.com/webmasters/answer/189077