### PR TITLE
base: remove index.html from default URL.

### DIFF
--- a/_layouts/base.html
+++ b/_layouts/base.html
@@ -41,8 +41,8 @@
     </script>
     {% for lang in site.langs %}
       {% if lang.langcode == "en" %}
-      <link rel="alternate" hreflang="en" href="{{ site.url | append: '/index.html' }}" />
-      <link rel="alternate" hreflang="x-default" href="{{ site.url | append: '/index.html' }}" />
+      <link rel="alternate" hreflang="en" href="{{ site.url }}" />
+      <link rel="alternate" hreflang="x-default" href="{{ site.url }}" />
       {% else %}
       <link rel="alternate" hreflang="{{ lang.langcode }}" href="{{ lang.langcode | downcase | append: '.html' | prepend: '/index_' | prepend: site.url }}" />
       {% endif %}


### PR DESCRIPTION
The `index.html` extension is redundant and looks ugly in e.g Google.