### PR TITLE
Remove outer margin from <figure>

### DIFF
--- a/css/screen.css
+++ b/css/screen.css
@@ -184,6 +184,14 @@ pre code {
   padding: 0 0 1em;
 }
 
+@media screen and (min-width: 700px) {
+  #informations .highlight {
+    margin-inline-end: 0;
+    -moz-margin-end: 0;
+    -webkit-margin-end: 0;
+  }
+}
+
 .button {
   text-align: center;
   margin: 1em 0 2em;


### PR DESCRIPTION
This removes the right margin from the `<figure>` elements (used for the command examples) to make it even with the top.

![screen shot 2016-10-15 at 00 43 14](https://cloud.githubusercontent.com/assets/15073177/19404691/81218b78-9270-11e6-9c2b-12670f542957.png)