### PR TITLE
Fixes for Hebrew translation

### DIFF
--- a/index_he.html
+++ b/index_he.html
@@ -20,8 +20,8 @@ pagecontent:
     what: הסקריפט יסביר מה הוא יעשה ויעצור לפני שיעשה זאת. קיימות אופציות התקנה נוספות <a href='https://github.com/Homebrew/brew/blob/master/docs/Installation.md#installation'>כאן</a>, אשר נדרשות ב-10.5
   doc:
     further: דוקומנטציה נוספת
-    blog: Homebrew Blog
-    community: Community Discussion
+    blog: בלוג Homebrew
+    community: דיון קהילה
   foot:
     code: .<a href="https://mxcl.github.io/">Max Howell</a> הקוד נכתב במקור ע״י
     page: .<a href="http://exomel.com">Rémi Prévost</a>, <a href="http://mikemcquaid.com">Mike McQuaid</a> and <a href="http://danilalo.com">Danielle Lalonde</a> האתר נבנה ע״י

--- a/index_he.html
+++ b/index_he.html
@@ -5,7 +5,7 @@ subtitle: מנהל החבילות החסר עבור macOS
 direction: rtl
 
 pagecontent:
-  question: מה Homebrew עושה؟
+  question: מה Homebrew עושה?
   what: Homebrew מתקין <a href="https://github.com/Homebrew/homebrew-core/tree/master/Formula" title="List of Homebrew packages">את מה שאתם צריכים</a>, שאפל לא התקינה.
   how: Homebrew מתקין חבילות לתיקיות משלהן ואז יוצר symlinks לקבצים שלהן לתוך <code>/usr/local</code>.
   prefix: Homebrew לא יתקין קבצים מחוץ לתיקייה שלו. אתם יכולים לשים התקנה של Homebrew היכן שתחפצו.

--- a/index_he.html
+++ b/index_he.html
@@ -23,6 +23,6 @@ pagecontent:
     blog: בלוג Homebrew
     community: דיון קהילה
   foot:
-    code: .<a href="https://mxcl.github.io/">Max Howell</a> הקוד נכתב במקור ע״י
-    page: .<a href="http://exomel.com">Rémi Prévost</a>, <a href="http://mikemcquaid.com">Mike McQuaid</a> and <a href="http://danilalo.com">Danielle Lalonde</a> האתר נבנה ע״י
+    code: הקוד נכתב במקור על ידי <a href="https://mxcl.github.io/">Max Howell</a>.
+    page: האתר נבנה על ידי <a href="http://exomel.com">Rémi Prévost</a>, <a href="http://mikemcquaid.com">Mike McQuaid</a> ו-<a href="http://danilalo.com">Danielle Lalonde</a>.
 ---


### PR DESCRIPTION
* Fixed issue with strange looking question mark.
* Translated the 'blog' and 'discussion' titles.
* Fixed credits in footer (the order of the text and links was wrong).