### PR TITLE
fix https mixed content issue

### DIFF
--- a/_layouts/base.html
+++ b/_layouts/base.html
@@ -74,7 +74,7 @@
 
     </div>
 
-    <a href="https://github.com/Homebrew/brew/"><img id="forkme" src="https://aral.github.com/fork-me-on-github-retina-ribbons/right-grey@2x.png" alt="Fork me on GitHub"></a>
+    <a href="https://github.com/Homebrew/brew/"><img id="forkme" src="https://aral.github.io/fork-me-on-github-retina-ribbons/right-grey@2x.png" alt="Fork me on GitHub"></a>
     <script>
       function selectText(elem) {
         if (document.selection) {


### PR DESCRIPTION
the current url for the fork-me img resource is transparently
redirecting to http, so fix the url to correctly use aral.github.io