### PR TITLE
Add missing FR translations

### DIFF
--- a/index_fr.html
+++ b/index_fr.html
@@ -1,7 +1,7 @@
 ---
 layout: index
 lang: fr
-subtitle: Le gestionnaire de paquets pour OS X
+subtitle: Le gestionnaire de paquets pour macOS
 
 pagecontent:
   question: Que fait Homebrew ?
@@ -10,17 +10,17 @@ pagecontent:
   prefix: Homebrew n’installera pas de fichiers en dehors de son préfixe, et vous pouvez placer Homebrew où vous le désirez.
   createpackages: Créez facilement vos propres paquets Homebrew.
   hack: Homebrew utilise git et ruby, vous pouvez donc faire des modifications sans crainte, sachant que vous pourrez facilement les annuler et les intégrer avec les mises à jour futures.
-  formula: "Les formules Homebrew sont de simples scripts Ruby :"
+  formula: "Les formules Homebrew sont de simples scripts Ruby&nbsp;:"
   editor: ouvre avec $EDITOR !
-  complement: Homebrew est un complément pour OS X. Installez vos gems avec <code>gem</code>, et leurs dépendances avec <code>brew</code>.
+  complement: Homebrew est un complément pour macOS. Installez vos gems avec <code>gem</code>, et leurs dépendances avec <code>brew</code>.
   install:
     install: Installer Homebrew
     paste: Copiez et collez dans une fenêtre du Terminal.
     what: Le script explique ce qu’il va faire, puis fait une pause avant de l’exécuter. Plus d’options d’installation sont disponibles <a href="https://github.com/Homebrew/brew/blob/master/docs/Installation.md#installation">ici</a> (requis pour 10.5).
   doc:
     further: Documentation additionnelle
-    blog: Homebrew Blog
-    community: Community Discussion
+    blog: Blog Homebrew
+    community: Discussions de la communauté
   foot:
     code: Code original par <a href="https://mxcl.github.io/">Max Howell</a>.
     page: Site web par <a href="http://exomel.com">Rémi Prévost</a>, <a href="http://mikemcquaid.com">Mike McQuaid</a> and <a href="http://danilalo.com">Danielle Lalonde</a>.


### PR DESCRIPTION
“OS X” → “macOS”; translate `blog` & `community`; enforce the French rule of non-breaking spaces where applicable.