### PR TITLE
Contrast for links and links-vs-body text

### DIFF
--- a/css/screen.css
+++ b/css/screen.css
@@ -21,8 +21,8 @@ html, body { height: 100%; }
 body {
   font-size: 150%;
   line-height: 1.4;
-  color: #F9D094;
-  background: #2E2A24;
+  color: #ffdead;
+  background: #25241d;
   position: relative;
   behavior: url("/js/ie6/csshover.htc");
   padding: 0 30px;
@@ -30,10 +30,10 @@ body {
 
 p,ul,ol,dl,table,pre { margin-bottom: 1em; }
 ul { margin-left: 20px; }
-a { text-decoration: none; cursor: pointer; color: #ba832c; font-weight: bold; }
+a { text-decoration: none; cursor: pointer; color: #ba700b; font-weight: bold; }
 a:focus { outline: 1px dotted; }
 a:visited {  }
-a:hover, a:focus { color: #d3a459; text-decoration: none; }
+a:hover, a:focus { color: #ffdead; text-decoration: none; }
 a *, button * { cursor: pointer; }
 hr { display: none; }
 small { font-size: 90%; }

--- a/css/screen.css
+++ b/css/screen.css
@@ -46,8 +46,8 @@ button::-moz-focus-inner { border: 0; padding: 1px; }
 span.amp { font-weight: normal; font-style: italic; font-size: 1.2em; line-height: 0.8; }
 h1,h2,h3,h4,h5,h6 { line-height: 1.1; }
 
-::selection { background: #745626; }
-::-moz-selection { background: #745626; }
+::selection { background: #ba700b; }
+::-moz-selection { background: #ba700b; }
 
 h1, h2, h3 {
   font-size: 420%;

--- a/css/screen.css
+++ b/css/screen.css
@@ -60,7 +60,7 @@ h2 {
   font-size: 300%;
   text-align: center;
   font-weight: 800;
-  color: #F9D094;
+  color: #ffdead;
   margin-top: 0.5em;
   margin-bottom: 0.1em;
 }
@@ -69,7 +69,7 @@ h3 {
   font-size: 125%;
   text-align: center;
   font-weight: 800;
-  color: #F9D094;
+  color: #ffdead;
   margin-top: 0.5em;
   margin-bottom: 0.1em;
 }
@@ -85,7 +85,7 @@ h3 {
 
 h1 a,
 h1 a:hover {
-  color: #F9D094;
+  color: #ffdead;
   font-weight: 900;
 }
 


### PR DESCRIPTION
This follows on from the discussion in https://github.com/Homebrew/homebrew.github.io/issues/154

I have been using http://jxnblk.com/colorable/demos/matrix/ to tweak the colours of:

 * the page background;
 * body text and
 * link text

so that they are, hopefully, easier to read - particularly so that links are more distinguishable from the body text.  Here is my first effort at this.

Here are the original colours and contrast ratios:
![homebrew-original](https://cloud.githubusercontent.com/assets/1125522/25500998/070115e0-2b89-11e7-9a2a-d2774eb17e17.png)
Of note:
 * Link text to page background is 4.33:1
 * Link text to body text is only 2.27:1

Here are the ones I currently have:
![homebrew-proposed](https://cloud.githubusercontent.com/assets/1125522/25501040/2b5a0230-2b89-11e7-9424-565439f4fd2b.png)
Of note:
 * Link text to page background is now only 4:1, which is not as good, though it still passes WCAG 2 Level AA under the "large text" exception, which states that if the text is large (which this qualifies as, due to being bold, on top of the larger base font size the site as a whole uses), then it's acceptable.
 * Link text to body text is now 3:1, which means more people are going to be able to differentiate between them.

I've been fiddling with the sliders for some time, but couldn't come up with a palette that felt the same as the original one that doesn't also have a slightly worse link text to background ratio.  In fact I am now somewhat inspired to write some code to exhaustively find the best such ratios between three colours, with artistic constraints, but that's probably not happening anytime soon...

Preserving the original character of the site was a priority and I hope you feel I've succeeded in doing this.  I'm still a little reticent due to the reduction in contrast between link text and page background (even though it's still considered acceptable under Level AA, it is worse than what was there originally) so might have another go with these sliders over the next few days again, to see if I can do any better.

A "wildcard" alternative approach, which could support even higher contrast throughout, would be to use a very different hue for the link colour, such as green (I think it looks quite cool, but imagine many may not!)

This PR also makes the following changes:

 * The new body text colour is used for headings too (so they match)
 * The new link text colour is used as the selection background colour (to simplify the palette)