### PR TITLE
analytics/index: fix typo

### DIFF
--- a/analytics/index.html
+++ b/analytics/index.html
@@ -5,7 +5,7 @@ layout: page
 <h3><a href="/analytics/install/">Install Events</a></h3>
 <p>The top formulae that have been installed either directly or pulled in as a dependency.</p>
 <h3><a href="/analytics/install-on-request/">Install On Request Events</a></h3>
-<p>The top formulae that have been installed on request (i.e. no pulled in as a dependency)</p>
+<p>The top formulae that have been installed on request (i.e. not pulled in as a dependency)</p>
 <h3><a href="/analytics/build-error/">Build Error Events</a></h3>
 <p>The top formulae which have build errors. Note these also include unsupported Homebrew configurations.</p>
 


### PR DESCRIPTION
fix analytics/index.html typo:
`(i.e. no pulled in as a dependency)` to `(i.e. not pulled in as a dependency)`