### PR TITLE
Link analytics formulas to braumeister

### DIFF
--- a/_layouts/analytics.html
+++ b/_layouts/analytics.html
@@ -14,7 +14,11 @@ layout: base
 {% for item in json.items %}
   <tr>
     <td class="number-data">#{{ item.number }}</td>
-    <td><code>{{ item.formula }}</code></td>
+    <td>
+      <a href="http://braumeister.org/formula/{{ item.formula }}">
+        <code>{{ item.formula }}</code>
+      </a>
+    </td>
     <td class="number-data">{{ item.count }}</td>
     <td class="number-data">{{ item.percent }}%</td>
   </tr>


### PR DESCRIPTION
I was looking at the shiny new analytics pages and wondering what a particular package did. To my dismay I had to search manually rather than clicking. This fixes that oversight.