### PR TITLE
Improve link colours for accessibility

### DIFF
--- a/_layouts/base.html
+++ b/_layouts/base.html
@@ -16,6 +16,9 @@
     <link rel="apple-touch-icon"href="/img/apple-touch-icon.png">
     <link rel="stylesheet" href="/css/screen.css" type="text/css" media="screen">
     <link rel="stylesheet" href="/css/pygments.css" type="text/css" media="screen">
+    {% if site.url == "http://localhost:4000" %}
+    <script src="https://github.com/Khan/tota11y/releases/download/0.1.3/tota11y.min.js"></script>
+    {% endif %}
     <script>
       (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
       (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),

--- a/css/screen.scss
+++ b/css/screen.scss
@@ -3,7 +3,7 @@
 
 $color_peach_orange_approx: #f9d094;
 $color_rangitoto_approx: #2e2a24;
-$color_marigold_approx: #ba832c;
+$color_marigold_approx: #be862d;
 $color_di_serria_approx: #d3a459;
 $color_dallas_approx: #745626;
 $black_25: rgba(0, 0, 0, 0.25);
@@ -195,6 +195,15 @@ a {
   &:hover {
     color: $color_di_serria_approx;
     text-decoration: underline;
+  }
+
+  h2, h3 {
+    color: $color_marigold_approx;
+
+    &:hover {
+      color: $color_di_serria_approx;
+      text-decoration: underline;
+    }
   }
 }
 


### PR DESCRIPTION
Add `tota11y` so it's always enabled in development and use it to identify areas where link contrast needs improved. Additionally, manually set the blog header links to be a visually distinguishable colour that again passes the `tota11y` tests.


Fixes https://github.com/Homebrew/homebrew.github.io/issues/154
Closes https://github.com/Homebrew/homebrew.github.io/pull/167