### PR TITLE
css: fix poor visibility in syntax highlighting

### DIFF
--- a/css/pygments.css
+++ b/css/pygments.css
@@ -33,7 +33,7 @@
 .ne { color: #990000; font-weight: bold } /* Name.Exception */
 .nf { color: #999999; font-weight: bold } /* Name.Function */
 .nn { color: #555555 } /* Name.Namespace */
-.nt { color: #000080 } /* Name.Tag */
+.nt { color: #008080 } /* Name.Tag */
 .nv { color: #008080 } /* Name.Variable */
 .ow { font-weight: bold } /* Operator.Word */
 .w { color: #bbbbbb } /* Text.Whitespace */


### PR DESCRIPTION
Some syntax highlighting on docs.brew.sh are illegible due to low contrast.

Before:

<img width="278" alt="image" src="https://user-images.githubusercontent.com/213484/31906023-d009c7a6-b7e4-11e7-8cae-932631a6bb16.png">

After:

<img width="284" alt="image" src="https://user-images.githubusercontent.com/213484/31906010-c37589a8-b7e4-11e7-9913-2ede2ec8dc7c.png">

Blocks https://github.com/Homebrew/brew/pull/3356