### PR TITLE
Add missing space to make `apple-touch-icon` work

### DIFF
--- a/_layouts/base.html
+++ b/_layouts/base.html
@@ -13,7 +13,7 @@
     {% feed_meta %}
     <meta name="viewport" content="width=device-width">
     <link rel="icon" type="image/x-icon" href="/img/favicon.ico">
-    <link rel="apple-touch-icon"href="/img/apple-touch-icon.png">
+    <link rel="apple-touch-icon" href="/img/apple-touch-icon.png">
     <link rel="stylesheet" href="/css/screen.css" type="text/css" media="screen">
     <link rel="stylesheet" href="/css/pygments.css" type="text/css" media="screen">
     {% if site.url == "http://localhost:4000" %}


### PR DESCRIPTION
There was an HTML validation error due to a missing space that was causing the `apple-touch-icon` not to work.