### PR TITLE
Russian subtitle translation fix

### DIFF
--- a/index_ru.html
+++ b/index_ru.html
@@ -1,7 +1,7 @@
 ---
 layout: index
 lang: ru
-subtitle: Менеджер недостающих пакетов для macOS
+subtitle: Недостающий менеджер пакетов для macOS
 
 pagecontent:
   question: Что делает Homebrew?


### PR DESCRIPTION
Original russian subtitle translates as "manager of missing packages", not "missing package manager"