### PR TITLE
Add Galician (Galego) to homebrew homepage locales

### DIFF
--- a/_data/locales/gl.yml
+++ b/_data/locales/gl.yml
@@ -1,4 +1,4 @@
-en:
+gl:
   locale_name: Galego
   subtitle: O xestor de paquetes de macOS que faltaba
   pagecontent:

--- a/_data/locales/gl.yml
+++ b/_data/locales/gl.yml
@@ -1,0 +1,28 @@
+en:
+  locale_name: Galego
+  subtitle: O xestor de paquetes de macOS que faltaba
+  pagecontent:
+    question: Que fai Homebrew?
+    what: Homebrew instala <a href="https://github.com/Homebrew/homebrew-core/tree/master/Formula" title="Listaxe de paquetes Homebrew">todo aquilo que precisas</a> e que Apple non instala.
+    how: Homebrew instala paquetes nos seus propios directorios e creando ligazóns simbólicas aos seus ficheiros en <code>/usr/local</code>.
+    prefix: Homebrew non vai instalar ficheiros fóra do seu prefixo, e ti podes poñer a instalación de Homebrew installation onde queiras.
+    createpackages: Crea doadamente os teus propios paquetes de Homebrew.
+    hack: Por embaixo é todo git e ruby, asi que fedella sabendo que podes voltar atrás doadamente as túas modificacións e integrar actualizacións.
+    formula: "As fórmulas de Homebrew son simples <i>scripts</i> de Ruby"
+    editor: ábrese co $EDITOR!
+    complement: Homebrew complementa a macOS. Instala as túas <i>gems</i> con <code>gem</code>, e as súas dependencias con <code>brew</code>.
+    install:
+      install: Instala Homebrew
+      paste: Pega este código nunha Terminal.
+      what: O <i>script</i> explica o que vai facer e fai unha pausa antes de executar nada. Hai máis opcións de instalación <a href='https://docs.brew.sh/Installation'>aquí</a>.
+    doc:
+      further: Documentación adicional
+      patreon: Doa en Patreon
+      blog: Blog de Homebrew
+      community: Discusión da Comunidade
+      formulae: Paquetes de Homebrew
+      analytics: Analíticas dos Datos
+    foot:
+      code: Homebrew foi creado por <a href="https://mxcl.github.io/">Max Howell</a>.
+      page: Páxina web de <a href="http://exomel.com">Rémi Prévost</a>, <a href="http://mikemcquaid.com">Mike McQuaid</a> e <a href="http://danilalo.com">Danielle Lalonde</a>.
+      translation: Tradución ao galego de Adolfo Núñez.

--- a/index_gl.html
+++ b/index_gl.html
@@ -1,0 +1,4 @@
+---
+layout: index
+lang: gal
+---


### PR DESCRIPTION
I have added translations for Galician (gl for ISO 639-1) made manually (not on transifex). More info about the language [here](https://en.wikipedia.org/wiki/Galician_language)