### PR TITLE
Use `.ruby-version` more widely

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -16,7 +16,6 @@ jobs:
       - name: Install Ruby
         uses: ruby/setup-ruby@943103cae7d3f1bb1e4951d5fcc7928b40e4b742 # v1.177.1
         with:
-          ruby-version: "2.7"
           bundler-cache: true
 
       - name: Run HTML Proofer tests

--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,7 @@
 source "https://rubygems.org"
 
+ruby file: ".ruby-version"
+
 gem "github-pages", group: :jekyll_plugins
 
 group :development do


### PR DESCRIPTION
This ensures it's used consistently by `bundle` and ruby/setup-ruby.