### PR TITLE
Update docsearch-js to 3.9.0

### DIFF
--- a/_layouts/base.html
+++ b/_layouts/base.html
@@ -228,8 +228,8 @@ algolia:
             referrerpolicy="no-referrer"
             onload="loadAnchors()"
             async></script>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/docsearch-js/3.8.3/umd/index.min.js" 
-            integrity="sha512-KimAzbZkqq4d6R95a3Fo124FpsXtPq2UH9xOI+IT931aUPiEqRak8jYT7VnpYP/7dkk33vzi1YhDzH+8T6qOrw==" 
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/docsearch-js/3.9.0/umd/index.min.js" 
+            integrity="sha512-GQvKUarIhGPpbful5R03aNwrhDKd/b+KdasOD9Uq0SFTZHJV14rly+Uss2pKazgeZz+G3JQ0wk1ximS6crma/w==" 
             crossorigin="anonymous" 
             referrerpolicy="no-referrer"
             onload="loadSearch('{{ page.lang }}', '{{ page.search_site }}')"


### PR DESCRIPTION
Updates the docsearch-js script `src` and `integrity` to the latest stable version on cdnjs.