### PR TITLE
Shorten installation URL to brew.sh/install.sh

### DIFF
--- a/_layouts/index.html
+++ b/_layouts/index.html
@@ -10,7 +10,7 @@ layout: base
         <br>
         <div class="copyable">
 {% highlight bash -%}
-/bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
+/bin/bash -c "$(curl -fsSL https://brew.sh/install.sh)"
 {%- endhighlight %}
         </div>
         <br>

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+exec /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"

--- a/install.sh
+++ b/install.sh
@@ -1,2 +1,5 @@
 #!/bin/bash
-exec /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
+if ! install_script="$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"; then
+  exit 1
+fi
+exec /bin/bash -c "$install_script"


### PR DESCRIPTION
This PR simplifies the Homebrew installation command displayed on the website by pointing it to a local wrapper script.

  Changes:
   - Added install.sh: A new, lightweight wrapper script at the repository root. It dynamically
     fetches and executes the official Homebrew install script from GitHub on the fly.
   - Updated _layouts/index.html: Changed the featured installation command from the long GitHub
     URL to the much shorter https://brew.sh/install.sh.

  Why this approach?
   - User Experience: The command is now much shorter and easier to read/share.
   - Reliability: By using a wrapper that fetches the raw script from the official Homebrew/install
     repository, we ensure users always get the most up-to-date and secure version without needing
     manual updates to this repository.
   - Safety: i have retained the /bin/bash -c "$(curl ...)" pattern. This is safer than piping
     directly to bash (curl | bash), as it ensures the script is fully downloaded and parsed before
     execution begins, protecting users from partial execution in case of network failure.