### PR TITLE
Skip feeds for non-blog sites

### DIFF
--- a/_layouts/base.html
+++ b/_layouts/base.html
@@ -50,7 +50,7 @@ algolia:
     {% endcomment -%}
     {% capture plugin_output -%}
       {% seo title=false -%}
-      {% if site.feed -%}
+      {% if site.feed and site.posts.size > 0 -%}
         {% include feed.html -%}
       {% endif -%}
     {% endcapture -%}


### PR DESCRIPTION
- Avoid emitting feed metadata when a Jekyll site has no posts.
- Let shared layouts work for docs sites without copying unused feed includes.