### PR TITLE
Note older Linux glibc is now Tier 2

### DIFF
--- a/_posts/2026-06-11-homebrew-6.0.0.md
+++ b/_posts/2026-06-11-homebrew-6.0.0.md
@@ -73,6 +73,7 @@ Homebrew published three security advisories:
 
 ### 🗑️ Deprecations
 
+- The [Ubuntu 24.04 CI migration](https://github.com/Homebrew/brew/pull/21761) raised the Linux baseline to `glibc` 2.39, so Linux systems with an older system `glibc` (such as Ubuntu 22.04 with `glibc` 2.35) are now [Tier 2](https://docs.brew.sh/Support-Tiers#tier-2): no new bottles (binary packages) are built for them and `brew doctor` warns. Use the [`ghcr.io/homebrew/brew`](https://github.com/Homebrew/brew/pkgs/container/brew) Docker image or upgrade to a [Tier 1](https://docs.brew.sh/Support-Tiers#tier-1) configuration such as Ubuntu 24.04.
 - [Homebrew deprecates default opt-ins.](https://github.com/Homebrew/brew/pull/22601)
 - [Homebrew deprecates now-default bundle and internal API environment variables such as `HOMEBREW_BUNDLE_NO_SECRETS` and `HOMEBREW_USE_INTERNAL_API`.](https://github.com/Homebrew/brew/pull/22641)
 - [Homebrew marks unused options for deprecation.](https://github.com/Homebrew/brew/pull/22478)


### PR DESCRIPTION
- the Ubuntu 24.04 CI migration raised the baseline to `glibc` 2.39, so systems like Ubuntu 22.04 are now Tier 2 with no new bottles
- point affected users at the `ghcr.io/homebrew/brew` image or a Tier 1 upgrade so the `brew doctor` warning is actionable